### PR TITLE
Add Google Antigravity as an ACP agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentrove
 
-Self-hosted AI coding workspace for running and orchestrating Claude Code, Codex, Copilot, Cursor, Grok, and OpenCode agents from one interface.
+Self-hosted AI coding workspace for running and orchestrating Antigravity, Claude Code, Codex, Copilot, Cursor, Grok, and OpenCode agents from one interface.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
@@ -11,7 +11,7 @@ Self-hosted AI coding workspace for running and orchestrating Claude Code, Codex
 
 ## What It Does
 
-- Runs Claude, Codex, Copilot, Cursor, Grok, and OpenCode through ACP adapters.
+- Runs Antigravity, Claude, Codex, Copilot, Cursor, Grok, and OpenCode through ACP adapters.
 - Gives each workspace its own Docker or host sandbox.
 - Combines chat, code editor, terminal, file tree, diffs, secrets, and git tools in one workspace.
 - Supports workspaces from empty folders, git clones, existing local folders, or GitHub repositories.
@@ -61,6 +61,8 @@ docker compose up -d
 ```
 
 Open [http://localhost:3000](http://localhost:3000).
+
+Antigravity authenticates with a `GEMINI_API_KEY` environment variable or Google OAuth completed in a terminal. Its ACP tokens live in `~/.gemini/antigravity-acp/`, separately from the Antigravity CLI login.
 
 ## Desktop
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -63,6 +63,23 @@ RUN set -eux; \
     curl -fsSL "https://x.ai/cli/grok-${version}-linux-${arch}" -o /usr/local/bin/grok; \
     chmod +x /usr/local/bin/grok
 
+RUN set -eux; \
+    version=20260818_01_RC01; \
+    case "$(uname -m)" in \
+      x86_64|amd64) platform=linux-x86_64 ;; \
+      aarch64|arm64) platform=linux-arm64 ;; \
+      *) exit 1 ;; \
+    esac; \
+    mkdir -p /opt/antigravity; \
+    curl -fsSL "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_${version}-${platform}.zip" \
+      -o /tmp/antigravity.zip; \
+    unzip /tmp/antigravity.zip -d /opt/antigravity; \
+    rm /tmp/antigravity.zip; \
+    chmod +x /opt/antigravity/agy_acp_server.par /opt/antigravity/localharness_external; \
+    printf '#!/bin/sh\nexec /opt/antigravity/agy_acp_server.par --uid= "$@"\n' \
+      > /usr/local/bin/agy-acp-server; \
+    chmod +x /usr/local/bin/agy-acp-server
+
 # Install uv package manager
 RUN curl -LsSf https://astral.sh/uv/install.sh | bash
 

--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -239,6 +239,18 @@ MODELS: dict[str, ModelInfo] = {
     "cursor:kimi-k2.5": ModelInfo("Kimi K2.5", AgentKind.CURSOR, 262_000),
     "grok:grok-4.6": ModelInfo("Grok 4.6", AgentKind.GROK, 500_000),
     "grok:grok-4.5": ModelInfo("Grok 4.5", AgentKind.GROK, 500_000),
+    "antigravity:gemini-3.7-flash": ModelInfo(
+        "Gemini 3.7 Flash", AgentKind.ANTIGRAVITY, 1_000_000
+    ),
+    "antigravity:gemini-3.6-flash": ModelInfo(
+        "Gemini 3.6 Flash", AgentKind.ANTIGRAVITY, 1_000_000
+    ),
+    "antigravity:gemini-3.5-flash": ModelInfo(
+        "Gemini 3.5 Flash", AgentKind.ANTIGRAVITY, 1_000_000
+    ),
+    "antigravity:gemini-3.1-pro": ModelInfo(
+        "Gemini 3.1 Pro", AgentKind.ANTIGRAVITY, 1_000_000
+    ),
     "opencode:opencode/big-pickle": ModelInfo(
         "Big Pickle (OpenCode)", AgentKind.OPENCODE, 200_000
     ),
@@ -2316,6 +2328,7 @@ MODELS: dict[str, ModelInfo] = {
 # are filtered ACP-exposed subsets (not full CLI/TUI chrome); skills are runtime.
 # Codex omits logout — too easy to hit from chat autocomplete.
 BUILTIN_SLASH_COMMANDS: dict[AgentKind, list[dict[str, str]]] = {
+    AgentKind.ANTIGRAVITY: [],
     AgentKind.CLAUDE: [
         {
             "value": "/compact",

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -1,6 +1,7 @@
 from typing import Literal, TypeAlias, TypedDict
 
 PermissionMode: TypeAlias = Literal[
+    "auto_edit",
     "default",
     "acceptEdits",
     "plan",
@@ -13,6 +14,7 @@ PermissionMode: TypeAlias = Literal[
     "read-only",
     "full-access",
     "ask",
+    "yolo",
 ]
 
 

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -10,6 +10,7 @@ from app.models.types import PermissionMode
 
 
 class AgentKind(str, Enum):
+    ANTIGRAVITY = "antigravity"
     CLAUDE = "claude"
     CODEX = "codex"
     COPILOT = "copilot"
@@ -25,6 +26,7 @@ class AgentKind(str, Enum):
 # models (Claude, GPT, etc.) — PDF parsing depends on the runtime model, so we
 # stay conservative and only declare image as guaranteed-inline for Copilot.
 NATIVE_FILE_TYPES: dict[AgentKind, frozenset[str]] = {
+    AgentKind.ANTIGRAVITY: frozenset({"image"}),
     AgentKind.CLAUDE: frozenset({"image", "pdf"}),
     AgentKind.CODEX: frozenset({"image"}),
     AgentKind.COPILOT: frozenset({"image"}),
@@ -105,6 +107,11 @@ COPILOT_KIMI_K3_VALID_THINKING_MODES = frozenset({"low", "high", "max"})
 # Cursor CLI exposes three ACP session modes (see https://cursor.com/docs/cli/acp).
 CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
 
+ANTIGRAVITY_SESSION_MODES = frozenset({"default", "auto_edit", "yolo"})
+ANTIGRAVITY_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
+ANTIGRAVITY_PRO_VALID_THINKING_MODES = frozenset({"low", "high"})
+ANTIGRAVITY_PRO_MODEL_ID = "antigravity:gemini-3.1-pro"
+
 # Current stable Grok advertises no ACP session modes and silently ignores
 # set_mode ids. `always-approve` uses the launch flag; `auto` keeps the CLI's
 # default classifier behavior (routine calls pass, risky ones prompt); `plan`
@@ -123,6 +130,7 @@ OPENCODE_SESSION_MODES = frozenset({"build", "plan"})
 
 # Full-execution mode per agent for unattended one-shots (Codex rejects unknown modes; avoid plan/read-only).
 NORMAL_SESSION_MODE: dict[AgentKind, PermissionMode] = {
+    AgentKind.ANTIGRAVITY: "yolo",
     AgentKind.CLAUDE: "default",
     AgentKind.CODEX: "auto",
     AgentKind.COPILOT: "agent",
@@ -133,7 +141,12 @@ NORMAL_SESSION_MODE: dict[AgentKind, PermissionMode] = {
 
 # Agents that support persona system-prompt replacement over ACP (Cursor/Copilot ignore it).
 PERSONAS_SUPPORTED_AGENTS: frozenset[AgentKind] = frozenset(
-    {AgentKind.CLAUDE, AgentKind.CODEX, AgentKind.GROK, AgentKind.OPENCODE}
+    {
+        AgentKind.CLAUDE,
+        AgentKind.CODEX,
+        AgentKind.GROK,
+        AgentKind.OPENCODE,
+    }
 )
 
 
@@ -142,6 +155,12 @@ THINKING_MODE_ORDER = ("low", "medium", "high", "xhigh", "max", "ultra")
 
 def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]:
     # Accepted thinking tiers; empty = no effort dial (thinking_mode ignored).
+    if agent_kind is AgentKind.ANTIGRAVITY:
+        return (
+            ANTIGRAVITY_PRO_VALID_THINKING_MODES
+            if model_id == ANTIGRAVITY_PRO_MODEL_ID
+            else ANTIGRAVITY_VALID_THINKING_MODES
+        )
     if agent_kind is AgentKind.CLAUDE:
         if model_id in CLAUDE_NO_EFFORT_MODEL_IDS:
             return frozenset()
@@ -196,7 +215,7 @@ def coerce_thinking_mode(
 def build_system_prompt_meta(
     system_prompt: str | None, is_full_replace: bool
 ) -> dict[str, Any]:
-    # Claude/Copilot _meta systemPrompt: str replaces; {"append": ...} appends.
+    # For adapters using _meta.systemPrompt, str replaces and {"append": ...} appends.
     if not system_prompt:
         return {}
     if is_full_replace:
@@ -263,7 +282,7 @@ class AgentAdapter(ABC):
         # UI permission mode → ACP session mode id (plan-mode transitions).
         raise NotImplementedError
 
-    def map_model_id(self, model_id: str) -> str:
+    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
         # Registry key → agent model id (default passthrough).
         return model_id
 
@@ -428,7 +447,7 @@ class CopilotCliAdapter(AgentAdapter):
             return COPILOT_SESSION_MODE_IDS["agent"]
         return COPILOT_SESSION_MODE_IDS[permission_mode]
 
-    def map_model_id(self, model_id: str) -> str:
+    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
         # Strip "copilot:" namespace for the CLI.
         return model_id.removeprefix("copilot:")
 
@@ -475,7 +494,7 @@ class CursorAgentAdapter(AgentAdapter):
             return "agent"
         return permission_mode
 
-    def map_model_id(self, model_id: str) -> str:
+    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
         # Strip "cursor:" namespace for the CLI.
         return model_id.removeprefix("cursor:")
 
@@ -546,9 +565,62 @@ class GrokAgentAdapter(AgentAdapter):
             return "always-approve"
         return permission_mode
 
-    def map_model_id(self, model_id: str) -> str:
+    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
         # Strip "grok:" namespace for the CLI.
         return model_id.removeprefix("grok:")
+
+
+class AntigravityAgentAdapter(AgentAdapter):
+    def __init__(self) -> None:
+        super().__init__(kind=AgentKind.ANTIGRAVITY)
+
+    def build_launch_config(
+        self,
+        *,
+        system_prompt: str | None,
+        system_prompt_is_full_replace: bool,
+        instructions_file_path: str | None = None,
+        reasoning_effort: str | None = None,
+        permission_mode: str | None = None,
+    ) -> LaunchConfig:
+        return LaunchConfig(binary="agy-acp-server")
+
+    def build_session_config(
+        self,
+        *,
+        system_prompt: str | None,
+        system_prompt_is_full_replace: bool,
+        model_id: str,
+        thinking_mode: str | None,
+        permission_mode: str,
+    ) -> SessionConfig:
+        reasoning_effort = (
+            "high"
+            if model_id == ANTIGRAVITY_PRO_MODEL_ID and thinking_mode == "medium"
+            else coerce_thinking_mode(
+                thinking_mode,
+                valid_thinking_modes(AgentKind.ANTIGRAVITY, model_id),
+                default="high",
+            )
+        )
+        return SessionConfig(
+            meta=build_system_prompt_meta(system_prompt, system_prompt_is_full_replace),
+            reasoning_effort=reasoning_effort,
+            permission=PermissionConfig(
+                session_mode=self.map_session_mode(permission_mode)
+            ),
+        )
+
+    def map_session_mode(self, permission_mode: str) -> str:
+        if permission_mode not in ANTIGRAVITY_SESSION_MODES:
+            return "yolo"
+        return permission_mode
+
+    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
+        effort = reasoning_effort or "high"
+        if model_id == ANTIGRAVITY_PRO_MODEL_ID and effort == "medium":
+            effort = "high"
+        return f"{model_id.removeprefix('antigravity:')}-{effort}"
 
 
 class OpencodeAgentAdapter(AgentAdapter):
@@ -629,12 +701,13 @@ class OpencodeAgentAdapter(AgentAdapter):
             return "plan"
         return permission_mode
 
-    def map_model_id(self, model_id: str) -> str:
+    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
         # Strip "opencode:" namespace for the CLI.
         return model_id.removeprefix("opencode:")
 
 
 AGENT_ADAPTERS: dict[AgentKind, AgentAdapter] = {
+    AgentKind.ANTIGRAVITY: AntigravityAgentAdapter(),
     AgentKind.CLAUDE: ClaudeAgentAdapter(),
     AgentKind.CODEX: CodexAgentAdapter(),
     AgentKind.COPILOT: CopilotCliAdapter(),

--- a/backend/app/services/acp/client.py
+++ b/backend/app/services/acp/client.py
@@ -52,6 +52,7 @@ _HEARTBEAT_TOOL_ID_RE = re.compile(r"-heartbeat-\d+$")
 
 # Valid ACP option_ids that match our PermissionMode literals directly.
 VALID_PERMISSION_MODES: set[str] = {
+    "auto_edit",
     "default",
     "acceptEdits",
     "plan",
@@ -64,10 +65,12 @@ VALID_PERMISSION_MODES: set[str] = {
     "full-access",
     "ask",
     "always-approve",
+    "yolo",
 }
 
 # Human option labels → PermissionMode when option_id isn't already a literal.
 PERMISSION_MODE_BY_OPTION_NAME: dict[str, PermissionMode] = {
+    "auto edit": "auto_edit",
     "default": "default",
     "accept edits": "acceptEdits",
     "plan": "plan",
@@ -79,6 +82,7 @@ PERMISSION_MODE_BY_OPTION_NAME: dict[str, PermissionMode] = {
     "read only": "read-only",
     "full access": "full-access",
     "always approve": "always-approve",
+    "yolo": "yolo",
 }
 
 # Grok delivers its ask_user_question tool as an ACP extension request

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -571,7 +571,9 @@ class AcpSession:
         model_id: str,
         reasoning_effort: str | None = None,
     ) -> None:
-        acp_model_id = AGENT_ADAPTERS[agent_kind].map_model_id(model_id)
+        acp_model_id = AGENT_ADAPTERS[agent_kind].map_model_id(
+            model_id, reasoning_effort
+        )
         # codex-acp encodes reasoning effort inside the model ID and rejects
         # bare IDs ("modelId[effort]" is the required format).
         if agent_kind == AgentKind.CODEX and reasoning_effort:

--- a/backend/app/services/skill.py
+++ b/backend/app/services/skill.py
@@ -55,6 +55,7 @@ class SkillService:
         # Claude-compatible skills; Grok scans .agents plus the Claude and Cursor
         # skill directories by default.
         result: dict[str, list[Path]] = {
+            AgentKind.ANTIGRAVITY.value: ns(workspace_path, base, ["gemini"]),
             AgentKind.CODEX.value: ns(workspace_path, base, ["codex", "agents"]),
             AgentKind.COPILOT.value: ns(workspace_path, base, ["copilot", "agents"]),
             AgentKind.CURSOR.value: ns(workspace_path, base, ["cursor", "agents"]),

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -16,7 +16,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.constants import REDIS_KEY_USER_STREAMS_LIVE
 from app.core.config import get_settings
 from app.models.db_models.workspace import Workspace
-from app.services.acp.adapters import AgentKind, ClaudeAgentAdapter, GrokAgentAdapter
+from app.services.acp.adapters import (
+    NORMAL_SESSION_MODE,
+    AgentKind,
+    AntigravityAgentAdapter,
+    ClaudeAgentAdapter,
+    GrokAgentAdapter,
+)
 from app.services.acp.session import AcpSessionConfig
 from app.services.sandbox_providers import SandboxProviderType
 from app.services.session_registry import session_registry
@@ -52,6 +58,7 @@ pytestmark = pytest.mark.anyio
 
 FAKE_AGENT_SCRIPT = Path(__file__).resolve().parent / "fake_acp_agent.py"
 BINARY_NAMES = [
+    "agy-acp-server",
     "claude-agent-acp",
     "codex-acp",
     "copilot",
@@ -66,6 +73,27 @@ DEFAULT_TURN_TEXT = "Hello from the fake agent."
 # content_type, not on parsing the file itself.
 PNG_BYTES = bytes.fromhex("89504e470d0a1a0a0000000d49484452")
 PDF_BYTES = b"%PDF-1.4\n%fake\n"
+
+
+def test_antigravity_adapter_configuration() -> None:
+    adapter = AntigravityAgentAdapter()
+    launch = adapter.build_launch_config(
+        system_prompt=None,
+        system_prompt_is_full_replace=False,
+    )
+
+    assert launch.binary == "agy-acp-server"
+    assert launch.cli_args == []
+    assert adapter.map_model_id("antigravity:gemini-3.7-flash", None) == (
+        "gemini-3.7-flash-high"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.7-flash", "low") == (
+        "gemini-3.7-flash-low"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.1-pro", "medium") == (
+        "gemini-3.1-pro-high"
+    )
+    assert NORMAL_SESSION_MODE[AgentKind.ANTIGRAVITY] == "yolo"
 
 
 @pytest.mark.parametrize(
@@ -391,6 +419,7 @@ def last_tool(message: dict[str, Any], tool_id: str) -> dict[str, Any]:
         "gpt-5.4",
         "copilot:gpt-5.4",
         "cursor:auto",
+        "antigravity:gemini-3.7-flash",
         "opencode:opencode/gpt-5-nano",
     ],
 )

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -70,6 +70,22 @@ async def test_list_models_returns_registered_models(
         "high",
         "xhigh",
     ]
+    assert by_id["antigravity:gemini-3.7-flash"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+    ]
+    assert by_id["antigravity:gemini-3.6-flash"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+    ]
+    assert by_id["antigravity:gemini-3.5-flash"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+    ]
+    assert by_id["antigravity:gemini-3.1-pro"]["thinking_modes"] == ["low", "high"]
     assert by_id["cursor:auto"]["thinking_modes"] == []
 
 

--- a/frontend/src/components/chat/model-selector/AgentFilterChips.tsx
+++ b/frontend/src/components/chat/model-selector/AgentFilterChips.tsx
@@ -7,6 +7,7 @@ import type { AgentKind } from '@/types/chat.types';
 import styles from './AgentFilterChips.module.scss';
 
 const AGENT_LABELS: Record<AgentKind, string> = {
+  antigravity: 'Antigravity',
   claude: 'Claude',
   codex: 'Codex',
   copilot: 'Copilot',

--- a/frontend/src/components/chat/permission-mode-selector/permissionModes.ts
+++ b/frontend/src/components/chat/permission-mode-selector/permissionModes.ts
@@ -86,6 +86,24 @@ export const GROK_PERMISSION_MODES: PermissionModeOption[] = [
   },
 ];
 
+export const ANTIGRAVITY_PERMISSION_MODES: PermissionModeOption[] = [
+  {
+    value: 'default',
+    label: 'Default',
+    description: 'Ask before running tools',
+  },
+  {
+    value: 'auto_edit',
+    label: 'Auto Edit',
+    description: 'Auto-approve file edits and ask for other tools',
+  },
+  {
+    value: 'yolo',
+    label: 'YOLO',
+    description: 'Auto-approve all tools',
+  },
+];
+
 export const OPENCODE_PERMISSION_MODES: PermissionModeOption[] = [
   {
     value: 'build',
@@ -100,6 +118,7 @@ export const OPENCODE_PERMISSION_MODES: PermissionModeOption[] = [
 ];
 
 export const MODES_BY_AGENT: Record<AgentKind, PermissionModeOption[]> = {
+  antigravity: ANTIGRAVITY_PERMISSION_MODES,
   claude: CLAUDE_PERMISSION_MODES,
   codex: CODEX_PERMISSION_MODES,
   copilot: COPILOT_PERMISSION_MODES,
@@ -109,6 +128,7 @@ export const MODES_BY_AGENT: Record<AgentKind, PermissionModeOption[]> = {
 };
 
 const DEFAULT_BY_AGENT: Record<AgentKind, PermissionMode> = {
+  antigravity: 'yolo',
   claude: 'bypassPermissions',
   codex: 'full-access',
   copilot: 'agent',

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -110,7 +110,18 @@ const GROK_XHIGH_THINKING_MODES: ThinkingModeOption[] = [
 ];
 const GROK_XHIGH_MODEL_IDS = new Set(['grok:grok-4.6']);
 
+const ANTIGRAVITY_THINKING_MODES: ThinkingModeOption[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+];
+const ANTIGRAVITY_PRO_THINKING_MODES: ThinkingModeOption[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'high', label: 'High' },
+];
+
 export const THINKING_MODES_BY_AGENT: Record<AgentKind, ThinkingModeOption[]> = {
+  antigravity: ANTIGRAVITY_THINKING_MODES,
   claude: CLAUDE_THINKING_MODES,
   codex: CODEX_THINKING_MODES,
   copilot: EMPTY_THINKING_MODES,
@@ -120,6 +131,7 @@ export const THINKING_MODES_BY_AGENT: Record<AgentKind, ThinkingModeOption[]> = 
 };
 
 const DEFAULT_BY_AGENT: Record<AgentKind, string> = {
+  antigravity: 'high',
   claude: 'high',
   codex: 'high',
   copilot: 'high',
@@ -132,6 +144,9 @@ export function getThinkingModesForAgent(
   agentKind: AgentKind,
   modelId?: string,
 ): ThinkingModeOption[] {
+  if (agentKind === 'antigravity' && modelId === 'antigravity:gemini-3.1-pro') {
+    return ANTIGRAVITY_PRO_THINKING_MODES;
+  }
   // Claude gates the effort dial per model: none at all on Haiku, and
   // `xhigh` only on selected high-capability models.
   if (agentKind === 'claude' && modelId && CLAUDE_NO_EFFORT_MODEL_IDS.has(modelId)) {
@@ -177,6 +192,13 @@ export function coerceThinkingModeForAgent(
   modelId?: string,
 ): string {
   const modes = getThinkingModesForAgent(agentKind, modelId);
+  if (
+    agentKind === 'antigravity' &&
+    modelId === 'antigravity:gemini-3.1-pro' &&
+    thinkingMode === 'medium'
+  ) {
+    return 'high';
+  }
   const requestedMode = THINKING_MODE_ORDER.includes(thinkingMode)
     ? thinkingMode
     : DEFAULT_BY_AGENT[agentKind];

--- a/frontend/src/components/ui/icons/AntigravityIcon.tsx
+++ b/frontend/src/components/ui/icons/AntigravityIcon.tsx
@@ -1,0 +1,10 @@
+import type { SVGProps } from 'react';
+
+export function AntigravityIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path d="m9 5-7 7 7 7M15 5l7 7-7 7M6 12h12" />
+      <ellipse cx="12" cy="12" rx="4" ry="10" transform="rotate(45 12 12)" />
+    </svg>
+  );
+}

--- a/frontend/src/components/ui/icons/providerIcons.ts
+++ b/frontend/src/components/ui/icons/providerIcons.ts
@@ -1,5 +1,6 @@
 import type { ComponentType, SVGProps } from 'react';
 import type { AgentKind } from '@/types/chat.types';
+import { AntigravityIcon } from './AntigravityIcon';
 import { ClaudeIcon } from './ClaudeIcon';
 import { CodexIcon } from './CodexIcon';
 import { CopilotIcon } from './CopilotIcon';
@@ -8,6 +9,7 @@ import { GrokIcon } from './GrokIcon';
 import { OpencodeIcon } from './OpencodeIcon';
 
 export const AGENT_ICONS: Record<AgentKind, ComponentType<SVGProps<SVGSVGElement>>> = {
+  antigravity: AntigravityIcon,
   claude: ClaudeIcon,
   codex: CodexIcon,
   copilot: CopilotIcon,

--- a/frontend/src/config/constants.ts
+++ b/frontend/src/config/constants.ts
@@ -21,6 +21,7 @@ export const MONACO_FONT_FAMILY =
 export const MOBILE_BREAKPOINT = 768;
 
 export const EMPTY_BUILTIN_COMMANDS: Record<AgentKind, SlashCommand[]> = {
+  antigravity: [],
   claude: [],
   codex: [],
   copilot: [],

--- a/frontend/src/hooks/useSkillsFilter.ts
+++ b/frontend/src/hooks/useSkillsFilter.ts
@@ -5,7 +5,15 @@ import { fuzzySearch } from '@/utils/fuzzySearch';
 
 // Chip order for the source filter — typed against AgentKind so it can't drift
 // from the canonical provider set if a kind is added, removed, or renamed.
-const SOURCE_ORDER: AgentKind[] = ['claude', 'codex', 'copilot', 'cursor', 'grok', 'opencode'];
+const SOURCE_ORDER: AgentKind[] = [
+  'antigravity',
+  'claude',
+  'codex',
+  'copilot',
+  'cursor',
+  'grok',
+  'opencode',
+];
 
 export function useSkillsFilter(items: CustomSkill[], workspaceId: string | undefined) {
   const [searchQuery, setSearchQuery] = useState('');

--- a/frontend/src/store/chatSettingsStore.ts
+++ b/frontend/src/store/chatSettingsStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 type PermissionMode =
+  | 'auto_edit'
   | 'default'
   | 'acceptEdits'
   | 'plan'
@@ -13,7 +14,8 @@ type PermissionMode =
   | 'read-only'
   | 'full-access'
   | 'ask'
-  | 'build';
+  | 'build'
+  | 'yolo';
 
 const DEFAULT_KEY = '__default__';
 export const DEFAULT_PERMISSION_MODE: PermissionMode = 'bypassPermissions';

--- a/frontend/src/store/sidebarFilters.ts
+++ b/frontend/src/store/sidebarFilters.ts
@@ -16,6 +16,7 @@ export const STATUS_OPTIONS: { value: SidebarStatusFilter; label: string }[] = [
 ];
 
 export const AGENT_OPTIONS: { value: AgentKind; label: string }[] = [
+  { value: 'antigravity', label: 'Antigravity' },
   { value: 'claude', label: 'Claude' },
   { value: 'codex', label: 'Codex' },
   { value: 'copilot', label: 'Copilot' },

--- a/frontend/src/types/chat.types.ts
+++ b/frontend/src/types/chat.types.ts
@@ -141,7 +141,14 @@ export interface CreateChatRequest {
   parent_chat_id?: string;
 }
 
-export type AgentKind = 'claude' | 'codex' | 'copilot' | 'cursor' | 'grok' | 'opencode';
+export type AgentKind =
+  | 'antigravity'
+  | 'claude'
+  | 'codex'
+  | 'copilot'
+  | 'cursor'
+  | 'grok'
+  | 'opencode';
 
 export interface Model {
   model_id: string;
@@ -169,7 +176,8 @@ export function getAgentKindForModelId(modelId: string | null | undefined): Agen
     return 'claude';
   }
   if (CODEX_MODEL_IDS.has(modelId)) return 'codex';
-  // Prefix convention for copilot/cursor/grok/opencode (avoids a second static set).
+  // Prefix convention for non-Codex providers (avoids a second static set).
+  if (modelId.startsWith('antigravity:')) return 'antigravity';
   if (modelId.startsWith('copilot:')) return 'copilot';
   if (modelId.startsWith('cursor:')) return 'cursor';
   if (modelId.startsWith('grok:')) return 'grok';

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -10,6 +10,7 @@ mcp = FastMCP("agentrove")
 # Unattended full-execution mode per agent. Backend rejects cross-agent modes;
 # mirrored here because this HTTP client can't import adapters.*_SESSION_MODES.
 PERMISSION_MODE_BY_AGENT = {
+    "antigravity": "yolo",
     "claude": "bypassPermissions",
     "codex": "full-access",
     "copilot": "autopilot",
@@ -63,7 +64,10 @@ async def list_workspaces() -> dict[str, Any]:
 
 @mcp.tool()
 async def list_models(
-    agent_kind: Literal["claude", "codex", "copilot", "cursor", "grok", "opencode"] | None = None,
+    agent_kind: Literal[
+        "antigravity", "claude", "codex", "copilot", "cursor", "grok", "opencode"
+    ]
+    | None = None,
 ) -> dict[str, Any]:
     """List available AI models, optionally filtered by agent_kind.
 

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -64,6 +64,24 @@ RUN useradd -m -s /bin/bash -u 1000 user && \
 
 COPY --chmod=755 sandbox/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 
+RUN set -eux; \
+    version=20260818_01_RC01; \
+    case "$(uname -m)" in \
+      x86_64|amd64) platform=linux-x86_64 ;; \
+      aarch64|arm64) platform=linux-arm64 ;; \
+      *) exit 1 ;; \
+    esac; \
+    mkdir -p /opt/antigravity /home/user/.local/bin; \
+    curl -fsSL "https://dl.google.com/agy-extensions/releases/linux/agy-acp-server-agy_acp_server_${version}-${platform}.zip" \
+      -o /tmp/antigravity.zip; \
+    unzip /tmp/antigravity.zip -d /opt/antigravity; \
+    rm /tmp/antigravity.zip; \
+    chmod +x /opt/antigravity/agy_acp_server.par /opt/antigravity/localharness_external; \
+    printf '#!/bin/sh\nexec /opt/antigravity/agy_acp_server.par --uid= "$@"\n' \
+      > /home/user/.local/bin/agy-acp-server; \
+    chmod +x /home/user/.local/bin/agy-acp-server; \
+    chown -R user:user /opt/antigravity /home/user/.local
+
 EXPOSE 3000 3001 5000 8000 8080 5173 4200 8888 4321 3030 5500 1234 4000
 
 USER user


### PR DESCRIPTION
Adds support for Google's Antigravity agent, released as a standalone ACP server ([registry entry](https://github.com/agentclientprotocol/registry/blob/main/antigravity-acp/agent.json)) and recently integrated in Zed.

## What's included

**Backend**
- New `AgentKind.ANTIGRAVITY` + `AntigravityAgentAdapter` (spawns `agy-acp-server`, ACP protocol v1 over stdio)
- 4 models: `antigravity:gemini-3.7-flash`, `antigravity:gemini-3.6-flash`, `antigravity:gemini-3.5-flash` (thinking low/medium/high) and `antigravity:gemini-3.1-pro` (low/high — the server has no pro-medium variant; medium is coerced to high). Thinking level maps into the server's model-id suffix (`gemini-3.7-flash-high` etc., server default `high`); there is no separate reasoning-effort config option.
- Session modes `default` / `auto_edit` / `yolo` via standard ACP `set_session_mode`; `yolo` (auto-approve all tools) is the unattended full-execution mode
- `map_model_id` gained an optional `reasoning_effort` param (backward-compatible; all other adapters unchanged in behavior)

**Docker (both images)**
- Downloads the pinned `agy_acp_server_20260818_01_RC01` zip for the build arch (x86_64/arm64), unpacks to `/opt/antigravity` (the `.par` binary and `localharness_external` must stay siblings), and installs an `agy-acp-server` wrapper that owns the Linux `--uid=` flag (prevents the binary from setuid-ing to `nobody` when root). Note: adds ~1.65GB per image — the artifact is just that big.

**Frontend**: `AgentKind` union + `antigravity:` prefix detection, new provider icon, permission-mode selector (Default / Auto Edit / YOLO, default YOLO), model-gated thinking modes, sidebar/filter labels, empty slash-command map.

**mcp-server**: `list_models` literal + unattended mode `yolo`.

## Deliberate exclusions
- **Personas**: not enabled — no evidence the server honors `_meta.systemPrompt` (couldn't probe past auth), and an ignored persona would silently no-op. Flip on once verified.
- **Desktop sidecar**: untouched; like cursor/grok, desktop host-mode expects the binary on PATH.
- No cost/pricing fields (don't exist in `ModelInfo`).

## Auth
The ACP server keeps its own token store (`~/.gemini/antigravity-acp/`), separate from the Antigravity CLI's login. Headless: set `GEMINI_API_KEY` as a custom env var. Otherwise complete the Google OAuth loopback flow in a terminal on the host. Unauthenticated `session/new` returns a clear "Authentication required" error.

## Verification
- Facts above verified against the live binary: downloaded the published zip, ran the ACP `initialize`/`session/new` handshake, and inspected `--helpfull` and the embedded source for modes/model ids
- Backend: full suite 394 passed; new tests cover adapter launch config, suffix/coercion mapping, unattended mode, and an end-to-end fake-agent round trip for `antigravity:gemini-3.7-flash`
- Frontend: typecheck, build, 767 tests, lint all pass
- Download URLs for both arches confirmed HTTP 200 (an earlier hyphen/underscore typo that 404'd was caught in review)
- Docker images not rebuilt in CI here; the install blocks mirror the existing cursor/grok patterns