### PR TITLE
Fix antigravity model ids for Google OAuth auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker compose up -d
 
 Open [http://localhost:3000](http://localhost:3000).
 
-Antigravity authenticates with a `GEMINI_API_KEY` environment variable or Google OAuth completed in a terminal. Its ACP tokens live in `~/.gemini/antigravity-acp/`, separately from the Antigravity CLI login.
+Antigravity supports authentication through Google OAuth completed in a terminal. Its ACP tokens live in `~/.gemini/antigravity-acp/`, separately from the Antigravity CLI login.
 
 ## Desktop
 

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -620,7 +620,18 @@ class AntigravityAgentAdapter(AgentAdapter):
         effort = reasoning_effort or "high"
         if model_id == ANTIGRAVITY_PRO_MODEL_ID and effort == "medium":
             effort = "high"
-        return f"{model_id.removeprefix('antigravity:')}-{effort}"
+        server_model_id = model_id.removeprefix("antigravity:")
+        # OAuth-path server IDs; API-key auth advertises different unsupported IDs.
+        oauth_model_ids = {
+            ("gemini-3.5-flash", "high"): "gemini-3-flash-agent",
+            ("gemini-3.5-flash", "medium"): "gemini-3.5-flash-low",
+            ("gemini-3.5-flash", "low"): "gemini-3.5-flash-extra-low",
+            ("gemini-3.1-pro", "high"): "gemini-pro-agent",
+            ("gemini-3.1-pro", "low"): "gemini-3.1-pro-low",
+        }
+        return oauth_model_ids.get(
+            (server_model_id, effort), f"{server_model_id}-{effort}"
+        )
 
 
 class OpencodeAgentAdapter(AgentAdapter):

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -90,8 +90,29 @@ def test_antigravity_adapter_configuration() -> None:
     assert adapter.map_model_id("antigravity:gemini-3.7-flash", "low") == (
         "gemini-3.7-flash-low"
     )
+    assert adapter.map_model_id("antigravity:gemini-3.6-flash", "medium") == (
+        "gemini-3.6-flash-medium"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.5-flash", "high") == (
+        "gemini-3-flash-agent"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.5-flash", "medium") == (
+        "gemini-3.5-flash-low"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.5-flash", "low") == (
+        "gemini-3.5-flash-extra-low"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.1-pro", None) == (
+        "gemini-pro-agent"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.1-pro", "high") == (
+        "gemini-pro-agent"
+    )
     assert adapter.map_model_id("antigravity:gemini-3.1-pro", "medium") == (
-        "gemini-3.1-pro-high"
+        "gemini-pro-agent"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.1-pro", "low") == (
+        "gemini-3.1-pro-low"
     )
     assert NORMAL_SESSION_MODE[AgentKind.ANTIGRAVITY] == "yolo"
 


### PR DESCRIPTION
Follow-up to #930. Live probing with an authenticated (Google OAuth) server revealed the valid model-id set depends on the auth method, and unknown ids hard-error with `-32602 "Model ... is not available for the current authentication method"` — so two of the four models failed at session setup with OAuth auth:

| Platform model + thinking | Old (API-key path) id | OAuth id (now used) |
|---|---|---|
| 3.5 Flash high | `gemini-3.5-flash-high` ❌ | `gemini-3-flash-agent` |
| 3.5 Flash medium | `gemini-3.5-flash-medium` ❌ | `gemini-3.5-flash-low` |
| 3.5 Flash low | `gemini-3.5-flash-low` (⚠ meant medium) | `gemini-3.5-flash-extra-low` |
| 3.1 Pro high | `gemini-3.1-pro-high` ❌ | `gemini-pro-agent` |
| 3.1 Pro low | `gemini-3.1-pro-low` ✓ | unchanged |
| 3.7/3.6 Flash (all) | ✓ | unchanged |

Google OAuth is the supported auth path for this deployment, so `map_model_id` targets the OAuth catalog directly (explicit lookup for the two irregular models, suffix rule otherwise).

**Verification:** every mapped id was accepted by a live authenticated server via `session/set_config_option` (7/7 OK). Backend suite 394 passed, ruff clean, frontend typecheck clean. Adapter tests assert every mapping including the `pro medium→high` coercion and `None→high` default.