### PR TITLE
Fix antigravity icon and hide context-usage indicator

### DIFF
--- a/frontend/src/components/chat/message-input/InputProvider.tsx
+++ b/frontend/src/components/chat/message-input/InputProvider.tsx
@@ -23,6 +23,7 @@ import { getAgentKindForModelId, type AgentKind, type Chat } from '@/types/chat.
 // Agents whose ACP servers don't emit UsageUpdate notifications — the context
 // window indicator stays at 0 for these, so we hide it entirely.
 const AGENTS_WITHOUT_USAGE_UPDATE: ReadonlySet<AgentKind> = new Set([
+  'antigravity',
   'copilot',
   'cursor',
   'grok',

--- a/frontend/src/components/ui/icons/AntigravityIcon.tsx
+++ b/frontend/src/components/ui/icons/AntigravityIcon.tsx
@@ -2,9 +2,11 @@ import type { SVGProps } from 'react';
 
 export function AntigravityIcon(props: SVGProps<SVGSVGElement>) {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
-      <path d="m9 5-7 7 7 7M15 5l7 7-7 7M6 12h12" />
-      <ellipse cx="12" cy="12" rx="4" ry="10" transform="rotate(45 12 12)" />
+    <svg viewBox="0 0 24 24" fill="none" {...props}>
+      <path
+        fill="currentColor"
+        d="M12 2c3.4 0 4.1 5.4 5.6 9.5 1.2 3.7 1.8 6.7 3.9 9 .7.7.6 1.3.1 1.5-.35.2-.75-.1-1.1-.4-1.9-1.6-2.8-4.3-4.6-7.1-1.1-1.7-2.2-1.8-3.9-1.8s-2.8.1-3.9 1.8c-1.8 2.8-2.7 5.5-4.6 7.1-.35.3-.75.6-1.1.4-.5-.2-.6-.8.1-1.5 2.1-2.3 2.7-5.3 3.9-9C7.9 7.4 8.6 2 12 2Z"
+      />
     </svg>
   );
 }


### PR DESCRIPTION
Two follow-ups to #930/#931 from user reports:

- **Context usage never progressed**: a live probe capturing every ACP notification during a prompt turn shows the Antigravity server emits no `usage_update` at all (only `agent_message_chunk` / `available_commands_update`), so the indicator can never move. Added `antigravity` to `AGENTS_WITHOUT_USAGE_UPDATE` alongside copilot/cursor/grok/opencode.
- **Provider icon** was a placeholder mash; replaced with a monochrome `currentColor` rendition of the official Antigravity bell-curve mark (visually verified against the logo asset).

Also investigated the report that the model claims a "low" thinking level when high is selected: traced end-to-end (UI → `thinking_mode` → `reasoning_effort` → `set_config_option`) and live-verified the session's model stays `gemini-3.7-flash-high` across turns — the selection is applied correctly; the model's self-report is a hallucination. No code change needed.

Frontend typecheck, lint, and build pass.