### PR TITLE
Add antigravity-specific frontend tool renderers

### DIFF
--- a/frontend/src/components/chat/tools/antigravity/EditTool.module.scss
+++ b/frontend/src/components/chat/tools/antigravity/EditTool.module.scss
@@ -1,0 +1,28 @@
+@use '@/styles/globals/typography' as type;
+
+.icon {
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+  color: var(--theme-text-secondary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-tertiary);
+  }
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.file-label {
+  margin-bottom: var(--space-1);
+  @include type.type-mono-meta;
+  @include type.type-overflow;
+  color: var(--theme-text-tertiary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-quaternary);
+  }
+}

--- a/frontend/src/components/chat/tools/antigravity/EditTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/EditTool.tsx
@@ -1,0 +1,80 @@
+import { memo } from 'react';
+import { FileEdit, FilePlus } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import { DiffView } from '../common/DiffView/DiffView';
+import { NumberedContent } from '../common/NumberedContent/NumberedContent';
+import { OpenInEditorButton } from '../common/OpenInEditorButton/OpenInEditorButton';
+import { buildUnifiedDiff } from '../common/buildUnifiedDiff';
+import type { AntigravityDiffBlock, AntigravityEditOutput } from './antigravityPayload';
+import styles from './EditTool.module.scss';
+
+const classifyEdit = (block: AntigravityDiffBlock): 'create' | 'edit' =>
+  !block.oldText ? 'create' : 'edit';
+
+function DiffEntry({ block }: { block: AntigravityDiffBlock }) {
+  if (classifyEdit(block) === 'create') {
+    return <NumberedContent content={block.newText ?? ''} />;
+  }
+  return <DiffView diff={buildUnifiedDiff(block.oldText ?? '', block.newText ?? '')} />;
+}
+
+export const EditTool = memo(function EditTool({ tool }: { tool: ToolAggregate }) {
+  const result = tool.result as AntigravityEditOutput | undefined;
+  const diffs = result?.diffs ?? [];
+  const first = diffs[0];
+  const operation = first ? classifyEdit(first) : 'edit';
+  const filePath = first?.path ?? '';
+  const fileName = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const target = diffs.length > 1 ? `${diffs.length} files` : fileName;
+
+  return (
+    <ToolCard
+      icon={
+        operation === 'create' ? (
+          <FilePlus className={styles.icon} />
+        ) : (
+          <FileEdit className={styles.icon} />
+        )
+      }
+      status={tool.status}
+      title={(status) => {
+        if (operation === 'create') {
+          switch (status) {
+            case 'completed':
+              return `Created ${target}`;
+            case 'failed':
+              return `Failed to create ${target}`;
+            default:
+              return `Creating ${target}`;
+          }
+        }
+        switch (status) {
+          case 'completed':
+            return `Edited ${target}`;
+          case 'failed':
+            return `Failed to edit ${target}`;
+          default:
+            return `Editing ${target}`;
+        }
+      }}
+      loadingContent={operation === 'create' ? 'Creating file...' : 'Applying changes...'}
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {diffs.length > 0 && (
+        <div className={styles.list}>
+          {diffs.map((block, index) => (
+            <div key={block.path ?? index}>
+              {diffs.length > 1 && block.path && (
+                <div className={styles['file-label']}>{extractFilename(block.path)}</div>
+              )}
+              <DiffEntry block={block} />
+            </div>
+          ))}
+        </div>
+      )}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/antigravity/ExecuteTool.module.scss
+++ b/frontend/src/components/chat/tools/antigravity/ExecuteTool.module.scss
@@ -1,0 +1,55 @@
+@use '@/styles/globals/typography' as type;
+
+.icon {
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+  color: var(--theme-text-secondary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-tertiary);
+  }
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.command {
+  @include type.type-mono(0.75rem, 1.625);
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--theme-text-secondary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-tertiary);
+  }
+}
+
+.prompt {
+  user-select: none;
+  color: var(--theme-text-quaternary);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
+}
+
+.cwd {
+  @include type.type-mono-meta;
+  @include type.type-overflow;
+  color: var(--theme-text-quaternary);
+}
+
+.badge {
+  @include type.type-meta(500);
+  flex-shrink: 0;
+  color: var(--theme-success-text);
+}
+
+.badge--failed {
+  color: var(--theme-error-text);
+}

--- a/frontend/src/components/chat/tools/antigravity/ExecuteTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/ExecuteTool.tsx
@@ -1,0 +1,64 @@
+import { memo } from 'react';
+import clsx from 'clsx';
+import { Terminal } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import toolText from '../common/toolText.module.scss';
+import type { AntigravityExecuteInput, AntigravityExecuteOutput } from './antigravityPayload';
+import styles from './ExecuteTool.module.scss';
+
+export const ExecuteTool = memo(function ExecuteTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as AntigravityExecuteInput | undefined;
+  const result = tool.result as AntigravityExecuteOutput | undefined;
+  const command = input?.command_line ?? result?.commandLine ?? tool.title?.trim() ?? '';
+  const workingDir = input?.working_dir ?? result?.workingDir ?? '';
+  const output = result?.combinedOutput ?? result?.formatted_output ?? '';
+  const exitCode = result?.exitCode ?? result?.exit_code;
+  const failed = typeof exitCode === 'number' && exitCode !== 0;
+  const label = command || 'command';
+
+  return (
+    <ToolCard
+      icon={<Terminal className={styles.icon} />}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return failed ? `Failed (exit ${exitCode}): ${label}` : `Ran: ${label}`;
+          case 'failed':
+            return `Failed: ${label}`;
+          default:
+            return `Running: ${label}`;
+        }
+      }}
+      loadingContent="Running command..."
+      error={tool.error}
+    >
+      {(command || workingDir || output || typeof exitCode === 'number') && (
+        <div className={styles.body}>
+          {command && (
+            <pre className={styles.command}>
+              <span className={styles.prompt}>$ </span>
+              {command}
+            </pre>
+          )}
+          {(workingDir || typeof exitCode === 'number') && (
+            <div className={styles.meta}>
+              {workingDir && <span className={styles.cwd}>{workingDir}</span>}
+              {typeof exitCode === 'number' && (
+                <span className={clsx(styles.badge, failed && styles['badge--failed'])}>
+                  exit {exitCode}
+                </span>
+              )}
+            </div>
+          )}
+          {output && (
+            <pre className={clsx(toolText['output-pre'], failed && toolText['output-pre--error'])}>
+              {output}
+            </pre>
+          )}
+        </div>
+      )}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/antigravity/ReadTool.module.scss
+++ b/frontend/src/components/chat/tools/antigravity/ReadTool.module.scss
@@ -1,0 +1,21 @@
+@use '@/styles/globals/typography' as type;
+
+.icon {
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+  color: var(--theme-text-secondary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-tertiary);
+  }
+}
+
+.path {
+  @include type.type-mono-meta;
+  @include type.type-overflow;
+  color: var(--theme-text-tertiary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-quaternary);
+  }
+}

--- a/frontend/src/components/chat/tools/antigravity/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/ReadTool.tsx
@@ -1,0 +1,36 @@
+import { memo } from 'react';
+import { FileSearch } from 'lucide-react';
+import type { ToolAggregate } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import { OpenInEditorButton } from '../common/OpenInEditorButton/OpenInEditorButton';
+import type { AntigravityReadInput } from './antigravityPayload';
+import styles from './ReadTool.module.scss';
+
+export const ReadTool = memo(function ReadTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as AntigravityReadInput | undefined;
+  const filePath = input?.absolute_path ?? '';
+  const label = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+
+  return (
+    <ToolCard
+      icon={<FileSearch className={styles.icon} />}
+      status={tool.status}
+      title={(status) => {
+        switch (status) {
+          case 'completed':
+            return `Read ${label}`;
+          case 'failed':
+            return `Failed to read ${label}`;
+          default:
+            return `Reading ${label}`;
+        }
+      }}
+      loadingContent="Reading file..."
+      error={tool.error}
+      actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
+    >
+      {filePath && <div className={styles.path}>{filePath}</div>}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/antigravity/antigravityPayload.ts
+++ b/frontend/src/components/chat/tools/antigravity/antigravityPayload.ts
@@ -1,0 +1,27 @@
+export interface AntigravityReadInput {
+  absolute_path?: string;
+}
+
+export interface AntigravityExecuteInput {
+  command_line?: string;
+  working_dir?: string;
+}
+
+export interface AntigravityExecuteOutput {
+  commandLine?: string;
+  workingDir?: string;
+  exitCode?: number;
+  exit_code?: number;
+  combinedOutput?: string;
+  formatted_output?: string;
+}
+
+export interface AntigravityDiffBlock {
+  path?: string | null;
+  oldText?: string | null;
+  newText?: string | null;
+}
+
+export interface AntigravityEditOutput {
+  diffs?: AntigravityDiffBlock[];
+}

--- a/frontend/src/components/chat/tools/registry.tsx
+++ b/frontend/src/components/chat/tools/registry.tsx
@@ -34,6 +34,18 @@ const cursorToolLoaders: Record<string, ToolModuleLoader> = {
   edit: () => import('./cursor/EditTool').then((m) => ({ default: m.EditTool })),
 };
 
+const antigravityToolLoaders: Record<string, ToolModuleLoader> = {
+  execute: () => import('./antigravity/ExecuteTool').then((m) => ({ default: m.ExecuteTool })),
+  read: () => import('./antigravity/ReadTool').then((m) => ({ default: m.ReadTool })),
+  edit: () => import('./antigravity/EditTool').then((m) => ({ default: m.EditTool })),
+  search: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
+  fetch: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
+  delete: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
+  move: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
+  think: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
+  other: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
+};
+
 // Grok surfaces its raw tool names via _meta["x.ai/tool"].name (the backend
 // extracts these as tool_name for grok sessions). Backend web searches carry
 // no x.ai/tool meta, so they arrive under the ACP kind "search".
@@ -120,6 +132,11 @@ const getOrCreateLazy = (key: string, loader: ToolModuleLoader) => {
 
 export const getToolComponent = (toolName: string, agentKind?: AgentKind): ToolComponent => {
   // Same ACP kind names across agents, different rawInput/rawOutput — prefer agent-specific loaders.
+  if (agentKind === 'antigravity') {
+    const loader = antigravityToolLoaders[toolName] ?? mcpLoader;
+    return getOrCreateLazy(`antigravity:${toolName}`, loader);
+  }
+
   if (agentKind === 'codex' && codexToolLoaders[toolName]) {
     return getOrCreateLazy(`codex:${toolName}`, codexToolLoaders[toolName]);
   }


### PR DESCRIPTION
Follow-up to #930–#932. Antigravity had no entry in the tool-renderer registry, so its tool calls fell through to the shared loader table where ACP kinds `edit`/`read`/`execute` collided with **Codex** renderers built for different payload shapes — `read` rendered an empty-bodied card, `execute` would have shown nothing useful.

**What's here**
- `tools/antigravity/` with Edit / Read / Execute renderers + payload types, mirroring the `tools/cursor/` conventions (ToolCard, DiffView, NumberedContent, OpenInEditorButton)
- Registry branch for `agentKind === 'antigravity'`: known kinds get the dedicated renderers, everything else (`search`/`fetch`/`delete`/`move`/`think`/`other`) routes to `MCPTool` — antigravity never hits the shared Codex table

**Grounded in live probes** (three real tool-using turns against the authenticated server):
- `edit`: diffs arrive on the initial `tool_call` as `content[].diff` (→ `tool.result.diffs`); `oldText` omitted on creates → rendered as file creation with numbered body, else unified diff
- `read`: path-only events (`rawInput.absolute_path`), file text never in tool events → compact path row + open-in-editor, no empty body
- `execute`: `rawInput {command_line, working_dir}` (snake_case), output in `tool_call_update.rawOutput.combinedOutput` with both `exitCode` and `exit_code` → command, cwd, output pane, failure-styled exit badge

Typecheck, lint, production build, and all 767 frontend tests pass.