### PR TITLE
Handle antigravity internal tool variants in renderers

### DIFF
--- a/frontend/src/components/chat/tools/antigravity/EditTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/EditTool.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import { FileEdit, FilePlus } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
-import { extractFilename } from '@/utils/format';
+import { extractFilename, humanizeToolTitle } from '@/utils/format';
 import { ToolCard } from '../common/ToolCard/ToolCard';
 import { DiffView } from '../common/DiffView/DiffView';
 import { NumberedContent } from '../common/NumberedContent/NumberedContent';
@@ -12,7 +12,6 @@ import type {
   AntigravityEditInput,
   AntigravityEditOutput,
 } from './antigravityPayload';
-import { humanizeToolTitle } from './humanizeToolTitle';
 import styles from './EditTool.module.scss';
 
 const classifyEdit = (block: AntigravityDiffBlock): 'create' | 'edit' =>

--- a/frontend/src/components/chat/tools/antigravity/EditTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/EditTool.tsx
@@ -7,7 +7,12 @@ import { DiffView } from '../common/DiffView/DiffView';
 import { NumberedContent } from '../common/NumberedContent/NumberedContent';
 import { OpenInEditorButton } from '../common/OpenInEditorButton/OpenInEditorButton';
 import { buildUnifiedDiff } from '../common/buildUnifiedDiff';
-import type { AntigravityDiffBlock, AntigravityEditOutput } from './antigravityPayload';
+import type {
+  AntigravityDiffBlock,
+  AntigravityEditInput,
+  AntigravityEditOutput,
+} from './antigravityPayload';
+import { humanizeToolTitle } from './humanizeToolTitle';
 import styles from './EditTool.module.scss';
 
 const classifyEdit = (block: AntigravityDiffBlock): 'create' | 'edit' =>
@@ -21,12 +26,18 @@ function DiffEntry({ block }: { block: AntigravityDiffBlock }) {
 }
 
 export const EditTool = memo(function EditTool({ tool }: { tool: ToolAggregate }) {
-  const result = tool.result as AntigravityEditOutput | undefined;
-  const diffs = result?.diffs ?? [];
+  const input = tool.input as AntigravityEditInput | undefined;
+  const result = tool.result as AntigravityEditOutput | string | undefined;
+  const summary = typeof result === 'string' ? result.trim() : '';
+  const diffs = typeof result === 'object' && result ? (result.diffs ?? []) : [];
   const first = diffs[0];
-  const operation = first ? classifyEdit(first) : 'edit';
-  const filePath = first?.path ?? '';
-  const fileName = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const operation = first
+    ? classifyEdit(first)
+    : /^(create|add)\b/i.test(summary)
+      ? 'create'
+      : 'edit';
+  const filePath = first?.path ?? input?.file_path ?? input?.target_file ?? '';
+  const fileName = filePath ? extractFilename(filePath) : humanizeToolTitle(tool.title) || 'file';
   const target = diffs.length > 1 ? `${diffs.length} files` : fileName;
 
   return (
@@ -40,6 +51,7 @@ export const EditTool = memo(function EditTool({ tool }: { tool: ToolAggregate }
       }
       status={tool.status}
       title={(status) => {
+        if (status === 'completed' && summary) return summary;
         if (operation === 'create') {
           switch (status) {
             case 'completed':

--- a/frontend/src/components/chat/tools/antigravity/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/ReadTool.tsx
@@ -5,12 +5,13 @@ import { extractFilename } from '@/utils/format';
 import { ToolCard } from '../common/ToolCard/ToolCard';
 import { OpenInEditorButton } from '../common/OpenInEditorButton/OpenInEditorButton';
 import type { AntigravityReadInput } from './antigravityPayload';
+import { humanizeToolTitle } from './humanizeToolTitle';
 import styles from './ReadTool.module.scss';
 
 export const ReadTool = memo(function ReadTool({ tool }: { tool: ToolAggregate }) {
   const input = tool.input as AntigravityReadInput | undefined;
-  const filePath = input?.absolute_path ?? '';
-  const label = filePath ? extractFilename(filePath) : tool.title?.trim() || 'file';
+  const filePath = input?.AbsolutePath ?? input?.absolute_path ?? '';
+  const label = filePath ? extractFilename(filePath) : humanizeToolTitle(tool.title) || 'file';
 
   return (
     <ToolCard

--- a/frontend/src/components/chat/tools/antigravity/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/ReadTool.tsx
@@ -1,11 +1,10 @@
 import { memo } from 'react';
 import { FileSearch } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
-import { extractFilename } from '@/utils/format';
+import { extractFilename, humanizeToolTitle } from '@/utils/format';
 import { ToolCard } from '../common/ToolCard/ToolCard';
 import { OpenInEditorButton } from '../common/OpenInEditorButton/OpenInEditorButton';
 import type { AntigravityReadInput } from './antigravityPayload';
-import { humanizeToolTitle } from './humanizeToolTitle';
 import styles from './ReadTool.module.scss';
 
 export const ReadTool = memo(function ReadTool({ tool }: { tool: ToolAggregate }) {

--- a/frontend/src/components/chat/tools/antigravity/SearchTool.module.scss
+++ b/frontend/src/components/chat/tools/antigravity/SearchTool.module.scss
@@ -1,0 +1,36 @@
+@use '@/styles/globals/typography' as type;
+
+.icon {
+  height: var(--space-3-5);
+  width: var(--space-3-5);
+  color: var(--theme-text-secondary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-tertiary);
+  }
+}
+
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.path {
+  @include type.type-mono-meta;
+  @include type.type-overflow;
+  color: var(--theme-text-tertiary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-quaternary);
+  }
+}
+
+.summary {
+  @include type.type-meta;
+  color: var(--theme-text-tertiary);
+
+  :global([data-theme='dark']) & {
+    color: var(--theme-text-quaternary);
+  }
+}

--- a/frontend/src/components/chat/tools/antigravity/SearchTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/SearchTool.tsx
@@ -1,0 +1,67 @@
+import { memo } from 'react';
+import { FileSearch, FolderSearch } from 'lucide-react';
+import type { ToolAggregate, ToolEventStatus } from '@/types/tools.types';
+import { extractFilename } from '@/utils/format';
+import { ToolCard } from '../common/ToolCard/ToolCard';
+import type { AntigravitySearchInput } from './antigravityPayload';
+import { humanizeToolTitle } from './humanizeToolTitle';
+import styles from './SearchTool.module.scss';
+
+const searchTitle = (
+  status: ToolEventStatus,
+  query: string,
+  directoryLabel: string,
+  fallback: string,
+): string => {
+  if (query) {
+    switch (status) {
+      case 'completed':
+        return `Searched '${query}'`;
+      case 'failed':
+        return `Failed to search '${query}'`;
+      default:
+        return `Searching '${query}'`;
+    }
+  }
+  if (directoryLabel) {
+    switch (status) {
+      case 'completed':
+        return `Listed ${directoryLabel}`;
+      case 'failed':
+        return `Failed to list ${directoryLabel}`;
+      default:
+        return `Listing ${directoryLabel}`;
+    }
+  }
+  return fallback;
+};
+
+export const SearchTool = memo(function SearchTool({ tool }: { tool: ToolAggregate }) {
+  const input = tool.input as AntigravitySearchInput | undefined;
+  const query = input?.query?.trim() ?? '';
+  const directoryPath = input?.directory_path ?? '';
+  const directoryLabel = directoryPath ? extractFilename(directoryPath) : '';
+  const fallback = humanizeToolTitle(tool.title) || 'Search';
+  const result = typeof tool.result === 'string' ? tool.result.trim() : '';
+  const title = searchTitle(tool.status, query, directoryLabel, fallback);
+  const showResult = result && result !== title;
+
+  return (
+    <ToolCard
+      icon={
+        query ? <FileSearch className={styles.icon} /> : <FolderSearch className={styles.icon} />
+      }
+      status={tool.status}
+      title={title}
+      loadingContent={query ? 'Searching files...' : 'Listing directory...'}
+      error={tool.error}
+    >
+      {(directoryPath || showResult) && (
+        <div className={styles.body}>
+          {directoryPath && <div className={styles.path}>{directoryPath}</div>}
+          {showResult && <div className={styles.summary}>{result}</div>}
+        </div>
+      )}
+    </ToolCard>
+  );
+});

--- a/frontend/src/components/chat/tools/antigravity/SearchTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/SearchTool.tsx
@@ -1,10 +1,9 @@
 import { memo } from 'react';
 import { FileSearch, FolderSearch } from 'lucide-react';
 import type { ToolAggregate, ToolEventStatus } from '@/types/tools.types';
-import { extractFilename } from '@/utils/format';
+import { extractFilename, humanizeToolTitle } from '@/utils/format';
 import { ToolCard } from '../common/ToolCard/ToolCard';
 import type { AntigravitySearchInput } from './antigravityPayload';
-import { humanizeToolTitle } from './humanizeToolTitle';
 import styles from './SearchTool.module.scss';
 
 const searchTitle = (

--- a/frontend/src/components/chat/tools/antigravity/antigravityPayload.ts
+++ b/frontend/src/components/chat/tools/antigravity/antigravityPayload.ts
@@ -1,5 +1,17 @@
 export interface AntigravityReadInput {
+  AbsolutePath?: string;
   absolute_path?: string;
+}
+
+export interface AntigravityEditInput {
+  file_path?: string;
+  target_file?: string;
+}
+
+export interface AntigravitySearchInput {
+  query?: string;
+  directory_path?: string;
+  num_results?: number;
 }
 
 export interface AntigravityExecuteInput {

--- a/frontend/src/components/chat/tools/antigravity/humanizeToolTitle.ts
+++ b/frontend/src/components/chat/tools/antigravity/humanizeToolTitle.ts
@@ -1,0 +1,5 @@
+export const humanizeToolTitle = (title: string): string =>
+  title
+    .replace(/^Running\s+/i, '')
+    .replace(/_/g, ' ')
+    .trim();

--- a/frontend/src/components/chat/tools/antigravity/humanizeToolTitle.ts
+++ b/frontend/src/components/chat/tools/antigravity/humanizeToolTitle.ts
@@ -1,5 +1,0 @@
-export const humanizeToolTitle = (title: string): string =>
-  title
-    .replace(/^Running\s+/i, '')
-    .replace(/_/g, ' ')
-    .trim();

--- a/frontend/src/components/chat/tools/registry.tsx
+++ b/frontend/src/components/chat/tools/registry.tsx
@@ -38,7 +38,7 @@ const antigravityToolLoaders: Record<string, ToolModuleLoader> = {
   execute: () => import('./antigravity/ExecuteTool').then((m) => ({ default: m.ExecuteTool })),
   read: () => import('./antigravity/ReadTool').then((m) => ({ default: m.ReadTool })),
   edit: () => import('./antigravity/EditTool').then((m) => ({ default: m.EditTool })),
-  search: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
+  search: () => import('./antigravity/SearchTool').then((m) => ({ default: m.SearchTool })),
   fetch: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
   delete: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),
   move: () => import('./claude/MCPTool').then((m) => ({ default: m.MCPTool })),

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -11,6 +11,12 @@ export const formatValue = (value: unknown): string => {
 
 export const extractFilename = (path: string): string => path.split('/').pop() ?? path;
 
+export const humanizeToolTitle = (title: string): string =>
+  title
+    .replace(/^Running\s+/i, '')
+    .replace(/_/g, ' ')
+    .trim();
+
 export function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;


### PR DESCRIPTION
Follow-up to #933, fixing the "Read Running view_file" cards reported in real chats.

**Root cause:** #933's renderers were built against payloads probed with client fs capabilities declared. Production agentrove sessions declare no fs support, so the server uses its *internal* tool variants with different shapes (live-probed with production-matching capabilities):

| kind | production shape | vs #933 assumption |
|---|---|---|
| read (`view_file`) | `rawInput.AbsolutePath` (PascalCase) | `absolute_path` |
| edit (`edit_file`) | `rawInput.file_path`; result is a summary **string** ("Create notes.txt"); **no diff content** | diffs in `result.diffs` |
| search (`search_directory`/`find_file`/`list_directory`) | `rawInput.{query, directory_path}`; string result | routed to generic MCPTool |

**Changes**
- ReadTool/EditTool accept both variants (old shapes kept as fallbacks); string edit results become the completed title with create-vs-edit icon inference
- New SearchTool: "Searched 'hello'" / "Listed \<dir\>" titles, path row, summary line
- `humanizeToolTitle` fallback (strips "Running ", underscores) so no card ever composes double-verb labels

Typecheck, lint, build, and all 767 frontend tests pass.