### PR TITLE
Open file:// chat links in the in-app editor

### DIFF
--- a/frontend/src/components/ui/markdown/MarkDown.tsx
+++ b/frontend/src/components/ui/markdown/MarkDown.tsx
@@ -1,4 +1,4 @@
-import ReactMarkdown from 'react-markdown';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
@@ -18,6 +18,12 @@ import styles from './MarkDown.module.scss';
 
 const VisualWidget = lazyNamed(() => import('../VisualWidget/VisualWidget'), 'VisualWidget');
 
+function markdownUrlTransform(url: string, key: string): string {
+  const colon = url.indexOf(':');
+  if (key === 'href' && colon > 0 && url.slice(0, colon).toLowerCase() === 'file') return url;
+  return defaultUrlTransform(url);
+}
+
 interface MarkdownBlockProps {
   content: string;
   remarkPlugins: Options['remarkPlugins'];
@@ -35,6 +41,7 @@ const MarkdownBlock = memo(function MarkdownBlock({
       remarkPlugins={remarkPlugins}
       rehypePlugins={rehypePlugins}
       components={MARKDOWN_COMPONENTS}
+      urlTransform={markdownUrlTransform}
     >
       {content}
     </ReactMarkdown>

--- a/frontend/src/components/ui/markdown/markdownComponents.module.scss
+++ b/frontend/src/components/ui/markdown/markdownComponents.module.scss
@@ -170,6 +170,19 @@
   }
 }
 
+.file-link {
+  @include type.type-mono;
+  border-radius: var(--radius-md);
+  padding: var(--space-0-5) var(--space-1);
+  background-color: var(--theme-surface-secondary);
+  text-decoration: none;
+  cursor: pointer;
+
+  @include responsive.hover {
+    text-decoration: underline;
+  }
+}
+
 .img {
   margin: var(--space-4) 0;
   height: auto;

--- a/frontend/src/components/ui/markdown/markdownComponents.tsx
+++ b/frontend/src/components/ui/markdown/markdownComponents.tsx
@@ -1,11 +1,21 @@
-import { Suspense } from 'react';
+import { Suspense, use } from 'react';
 import { lazyNamed } from '@/utils/lazyNamed';
 import type { Components } from 'react-markdown';
-import type { AnchorHTMLAttributes, HTMLAttributes, ImgHTMLAttributes } from 'react';
+import type {
+  AnchorHTMLAttributes,
+  HTMLAttributes,
+  ImgHTMLAttributes,
+  KeyboardEvent,
+  MouseEvent,
+} from 'react';
 import clsx from 'clsx';
 import { AttachmentViewer } from '../attachment-viewer/AttachmentViewer';
 import { Link } from '../primitives/Link/Link';
 import { isImageUrl } from '@/utils/fileTypes';
+import { findFileByToolPath, parseFileHref } from '@/utils/file';
+import type { FileStructure } from '@/types/file-system.types';
+import { ChatContext } from '@/contexts/ChatContextDefinition';
+import { useUIStore } from '@/store/uiStore';
 import { createImageAttachment } from './markdownParsing';
 import { CodeBlock } from './CodeBlock';
 import styles from './markdownComponents.module.scss';
@@ -24,6 +34,36 @@ interface CodeProps extends CommonProps {
 type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement>;
 
 type ImageProps = ImgHTMLAttributes<HTMLImageElement>;
+
+type FileLinkChat = { chatId: string | undefined; fileStructure: FileStructure[] } | null;
+
+function openWorkspaceFile(href: string, chat: FileLinkChat) {
+  if (!chat) return;
+  const parsed = parseFileHref(href);
+  if (!parsed) return;
+  const mapped = findFileByToolPath(chat.fileStructure, parsed.path);
+  useUIStore.getState().openFileInEditor(mapped?.path ?? parsed.path, chat.chatId, parsed.line);
+}
+
+function handleFileLinkClick(
+  event: MouseEvent<HTMLAnchorElement>,
+  href: string,
+  chat: FileLinkChat,
+) {
+  event.preventDefault();
+  event.stopPropagation();
+  openWorkspaceFile(href, chat);
+}
+
+function handleFileLinkKeyDown(
+  event: KeyboardEvent<HTMLAnchorElement>,
+  href: string,
+  chat: FileLinkChat,
+) {
+  if (event.key !== 'Enter' && event.key !== ' ') return;
+  event.preventDefault();
+  openWorkspaceFile(href, chat);
+}
 
 // Module-level so every MarkdownBlock sees the same components identity forever
 // — the memo on completed blocks never busts after CodeBlock took copy state.
@@ -171,7 +211,27 @@ export const MARKDOWN_COMPONENTS: Components = {
     </blockquote>
   ),
 
-  a: ({ children, href, ...props }: LinkProps) => {
+  a: function MarkdownAnchor({ children, href, ...props }: LinkProps) {
+    // useChatContext throws outside ChatProvider (file preview, landing, etc.).
+    const chat = use(ChatContext);
+
+    if (href && /^file:/i.test(href)) {
+      return (
+        <Link
+          {...props}
+          variant="unstyled"
+          className={clsx(styles.link, styles['file-link'])}
+          role="button"
+          tabIndex={0}
+          onClick={(event) => handleFileLinkClick(event, href, chat)}
+          onAuxClick={(event) => handleFileLinkClick(event, href, chat)}
+          onKeyDown={(event) => handleFileLinkKeyDown(event, href, chat)}
+        >
+          {children}
+        </Link>
+      );
+    }
+
     if (href && isImageUrl(href)) {
       return <AttachmentViewer attachments={[createImageAttachment(href)]} />;
     }

--- a/frontend/src/utils/file.ts
+++ b/frontend/src/utils/file.ts
@@ -127,6 +127,24 @@ export function findFileByToolPath(
   return undefined;
 }
 
+const FILE_HREF_LINE_RE = /^#L(\d+)(?:-L?\d+)?$/i;
+
+export function parseFileHref(href: string): { path: string; line?: number } | null {
+  if (!/^file:/i.test(href)) return null;
+  try {
+    const url = new URL(href);
+    if (url.protocol.toLowerCase() !== 'file:') return null;
+    const path = decodeURIComponent(url.pathname);
+    if (!path || path === '/') return null;
+    const match = FILE_HREF_LINE_RE.exec(url.hash);
+    if (!match) return { path };
+    const line = Number(match[1]);
+    return line > 0 ? { path, line } : { path };
+  } catch {
+    return null;
+  }
+}
+
 export function detectLanguage(path: string): string {
   if (!path) return 'javascript';
 


### PR DESCRIPTION
## What

Assistant messages cite files and code symbols as GitHub-style markdown links with the `file://` scheme (`[utils.py](file:///abs/path/utils.py#L42)`). Previously react-markdown's default `urlTransform` stripped those hrefs to `""`, rendering dead text. Clicking one now opens the file in AgentRove's in-app editor pane for the current chat and reveals line N when the link carries a `#L<N>` fragment.

## How

- **`MarkDown.tsx`** — custom `markdownUrlTransform` keeps `file:` URLs for the `href` attribute key only; everything else (including image `src`) still goes through `defaultUrlTransform`, so `javascript:`/`data:`/`vscode:` stay stripped.
- **`markdownComponents.tsx`** — new `MarkdownAnchor` branch renders `file:` links as a mono pill with **no navigable href** (`role="button"`, `tabIndex=0`, click/aux-click/Enter+Space handlers), so right-click → open-in-new-tab and drag have nothing to navigate. Clicks go through the existing `uiStore.openFileInEditor(path, chatId, line)` seam → `pendingFileOpen` → Monaco `revealLineInCenter`. Chat id comes from `use(ChatContext)`, so rendering outside `ChatProvider` degrades to a no-op.
- **`file.ts`** — `parseFileHref` extracts the absolute path and `#L42` / `#L42-L50` (first line); paths map to tree paths via the existing `findFileByToolPath`, falling back to the stub-path behavior for files not in the tree yet.
- **`markdownComponents.module.scss`** — `.file-link` pill styling reusing the inline-code tokens.

Frontend-only; works identically in the browser deployment and the Tauri desktop app. No new dependencies, no Tauri capability changes.

## Verification

- `npm run lint`, `typecheck`, `build` — pass.
- Existing suites: `file.test.ts` (30), `uiStore.test.ts` (32), `editorNavigation.test.ts` (13) — pass.
- Throwaway RTL render: file link has no `href^="file:"` in the DOM, click and Enter set `pendingFileOpen` with the parsed line; `![x](file:///...)` image src stripped; https links/images unchanged; `javascript:` hrefs still render as `href=""`.
- Reviewed in two rounds (logic review caught and we fixed: navigable-href escape via context menu/drag, and the transform leaking `file:` into image srcs); blind re-review clean.
- Not verified live: Monaco scroll in a running window — one manual click recommended.