### PR TITLE
Surface real Docker errors on workspace create

### DIFF
--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -5,11 +5,13 @@ import posixpath
 import shlex
 import tarfile
 import uuid
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, AsyncIterator
 
 import aiodocker
+import aiohttp
 
 from app.constants import (
     DOCKER_STATUS_RUNNING,
@@ -64,9 +66,34 @@ class LocalDockerProvider(SandboxProvider):
                     self._docker = aiodocker.Docker(url=self.config.host)
                 else:
                     self._docker = aiodocker.Docker()
-            except Exception as e:
-                raise SandboxException(f"Failed to connect to Docker: {e}")
+            except ValueError as e:
+                raise SandboxException(
+                    f"Failed to connect to Docker — is Docker running? ({e})",
+                    status_code=502,
+                ) from e
         return self._docker
+
+    @asynccontextmanager
+    async def _docker_operation(
+        self, operation: str, catch_timeout: bool = True
+    ) -> AsyncIterator[None]:
+        exception_types: tuple[type[Exception], ...] = (
+            aiodocker.exceptions.DockerError,
+            aiohttp.ClientError,
+        )
+        if catch_timeout:
+            exception_types += (asyncio.TimeoutError,)
+        try:
+            yield
+        except exception_types as e:
+            is_connectivity_error = isinstance(
+                e, (aiohttp.ClientError, asyncio.TimeoutError)
+            ) or (isinstance(e, aiodocker.exceptions.DockerError) and e.status == 900)
+            hint = " — is Docker running?" if is_connectivity_error else ""
+            raise SandboxException(
+                f"Failed to {operation}{hint} ({e})",
+                status_code=502,
+            ) from e
 
     @staticmethod
     def _parse_mem_limit(mem_str: str) -> int:
@@ -140,14 +167,15 @@ class LocalDockerProvider(SandboxProvider):
         return container
 
     async def create_sandbox(self, workspace_path: str | None = None) -> str:
-        sandbox_id = str(uuid.uuid4())[:12]
-        container = await self._create_container(
-            sandbox_id, workspace_path=workspace_path
-        )
-        if workspace_path:
-            await self._fix_workspace_ownership(container, workspace_path)
-        self._containers[sandbox_id] = container
-        return sandbox_id
+        async with self._docker_operation("create Docker sandbox"):
+            sandbox_id = str(uuid.uuid4())[:12]
+            container = await self._create_container(
+                sandbox_id, workspace_path=workspace_path
+            )
+            if workspace_path:
+                await self._fix_workspace_ownership(container, workspace_path)
+            self._containers[sandbox_id] = container
+            return sandbox_id
 
     async def _fix_workspace_ownership(
         self, container: Any, workspace_path: str
@@ -172,45 +200,55 @@ class LocalDockerProvider(SandboxProvider):
             return await docker.containers.get(
                 f"{DOCKER_SANDBOX_CONTAINER_PREFIX}{sandbox_id}"
             )
-        except Exception:
-            return None
+        except aiodocker.exceptions.DockerError as e:
+            if e.status == 404:
+                return None
+            raise
 
     async def connect_sandbox(self, sandbox_id: str) -> bool:
-        if sandbox_id in self._containers:
-            container = self._containers[sandbox_id]
-            info = await container.show()
-            status: str = info.get("State", {}).get("Status", "")
-            if status == DOCKER_STATUS_RUNNING:
+        async with self._docker_operation("connect to Docker sandbox"):
+            if sandbox_id in self._containers:
+                container = self._containers[sandbox_id]
+                try:
+                    info = await container.show()
+                except aiodocker.exceptions.DockerError as e:
+                    if e.status != 404:
+                        raise
+                    self._containers.pop(sandbox_id, None)
+                else:
+                    status: str = info.get("State", {}).get("Status", "")
+                    if status == DOCKER_STATUS_RUNNING:
+                        return True
+                    self._containers.pop(sandbox_id, None)
+
+            container = await self._get_container_by_id(sandbox_id)
+            if container:
+                self._containers[sandbox_id] = container
                 return True
-            self._containers.pop(sandbox_id, None)
 
-        container = await self._get_container_by_id(sandbox_id)
-        if container:
-            self._containers[sandbox_id] = container
-            return True
-
-        return False
+            return False
 
     async def delete_sandbox(self, sandbox_id: str) -> None:
-        container = self._containers.get(sandbox_id)
+        async with self._docker_operation("delete Docker sandbox"):
+            container = self._containers.get(sandbox_id)
 
-        if not container:
-            container = await self._get_container_by_id(sandbox_id)
             if not container:
-                return
+                container = await self._get_container_by_id(sandbox_id)
+                if not container:
+                    return
 
-        try:
-            await container.stop(t=5)
-        except Exception:
-            pass
-        try:
-            await container.delete(force=True)
-        except Exception:
-            pass
+            try:
+                try:
+                    await container.stop(t=5)
+                except aiodocker.exceptions.DockerError as e:
+                    logger.warning(
+                        "Failed to stop Docker sandbox %s: %s", sandbox_id, e
+                    )
+                await container.delete(force=True)
+            finally:
+                self._containers.pop(sandbox_id, None)
 
-        self._containers.pop(sandbox_id, None)
-
-        logger.info("Successfully deleted Docker sandbox %s", sandbox_id)
+            logger.info("Successfully deleted Docker sandbox %s", sandbox_id)
 
     async def list_files(
         self,
@@ -286,28 +324,31 @@ class LocalDockerProvider(SandboxProvider):
         envs: dict[str, str] | None = None,
         timeout: int = SANDBOX_DEFAULT_COMMAND_TIMEOUT,
     ) -> CommandResult:
-        # aiodocker merges stdout/stderr, so stderr is always empty.
-        container = await self._get_container(sandbox_id)
-        env_list = [f"{k}={v}" for k, v in (envs or {}).items()]
+        async with self._docker_operation(
+            "execute Docker command", catch_timeout=False
+        ):
+            # aiodocker merges stdout/stderr, so stderr is always empty.
+            container = await self._get_container(sandbox_id)
+            env_list = [f"{k}={v}" for k, v in (envs or {}).items()]
 
-        # Exec from the workspace root so relative cwd prefixes (e.g.
-        # `cd '.worktrees/abc' && ...`) resolve against the project files,
-        # not the user's home dir.
-        exec_obj = await container.exec(
-            cmd=["bash", "-c", command],
-            environment=env_list,
-            workdir=self.workspace_root,
-        )
-
-        try:
-            exit_code, output_str = await asyncio.wait_for(
-                self._collect_exec_output(exec_obj),
-                timeout=timeout,
+            # Exec from the workspace root so relative cwd prefixes (e.g.
+            # `cd '.worktrees/abc' && ...`) resolve against the project files,
+            # not the user's home dir.
+            exec_obj = await container.exec(
+                cmd=["bash", "-c", command],
+                environment=env_list,
+                workdir=self.workspace_root,
             )
-        except asyncio.TimeoutError:
-            raise TimeoutError(f"Command execution timed out after {timeout}s")
 
-        return CommandResult(stdout=output_str, stderr="", exit_code=exit_code)
+            try:
+                exit_code, output_str = await asyncio.wait_for(
+                    self._collect_exec_output(exec_obj),
+                    timeout=timeout,
+                )
+            except asyncio.TimeoutError:
+                raise TimeoutError(f"Command execution timed out after {timeout}s")
+
+            return CommandResult(stdout=output_str, stderr="", exit_code=exit_code)
 
     @staticmethod
     def _build_file_tar(filename: str, content_bytes: bytes) -> bytes:
@@ -328,56 +369,61 @@ class LocalDockerProvider(SandboxProvider):
         path: str,
         content: str | bytes,
     ) -> None:
-        container = await self._get_container(sandbox_id)
-        normalized_path = self.resolve_workspace_path(path)
-        content_bytes = content.encode("utf-8") if isinstance(content, str) else content
-
-        parent_dir = str(Path(normalized_path).parent)
-        mkdir_exec = await container.exec(
-            cmd=["mkdir", "-p", parent_dir],
-        )
-        mkdir_exit_code, mkdir_output = await self._collect_exec_output(mkdir_exec)
-        if mkdir_exit_code != 0:
-            raise SandboxException(
-                f"Failed to create directory {parent_dir}: {mkdir_output}"
+        async with self._docker_operation("write file in Docker sandbox"):
+            container = await self._get_container(sandbox_id)
+            normalized_path = self.resolve_workspace_path(path)
+            content_bytes = (
+                content.encode("utf-8") if isinstance(content, str) else content
             )
-        tar = self._build_file_tar(Path(normalized_path).name, content_bytes)
-        await container.put_archive(parent_dir, tar)
+
+            parent_dir = str(Path(normalized_path).parent)
+            mkdir_exec = await container.exec(
+                cmd=["mkdir", "-p", parent_dir],
+            )
+            mkdir_exit_code, mkdir_output = await self._collect_exec_output(mkdir_exec)
+            if mkdir_exit_code != 0:
+                raise SandboxException(
+                    f"Failed to create directory {parent_dir}: {mkdir_output}"
+                )
+            tar = self._build_file_tar(Path(normalized_path).name, content_bytes)
+            await container.put_archive(parent_dir, tar)
 
     async def write_temp_file(self, sandbox_id: str, content: str) -> str:
-        # /tmp always exists and is world-writable, so no mkdir is needed.
-        container = await self._get_container(sandbox_id)
-        filename = f"agentrove-codex-{uuid.uuid4().hex}.md"
-        tar = self._build_file_tar(filename, content.encode("utf-8"))
-        await container.put_archive("/tmp", tar)
-        return posixpath.join("/tmp", filename)
+        async with self._docker_operation("write temporary file in Docker sandbox"):
+            # /tmp always exists and is world-writable, so no mkdir is needed.
+            container = await self._get_container(sandbox_id)
+            filename = f"agentrove-codex-{uuid.uuid4().hex}.md"
+            tar = self._build_file_tar(filename, content.encode("utf-8"))
+            await container.put_archive("/tmp", tar)
+            return posixpath.join("/tmp", filename)
 
     async def read_file(
         self,
         sandbox_id: str,
         path: str,
     ) -> FileContent:
-        # get_archive returns a tar; take the first member.
-        container = await self._get_container(sandbox_id)
-        normalized_path = self.resolve_workspace_path(path)
+        async with self._docker_operation("read file from Docker sandbox"):
+            # get_archive returns a tar; take the first member.
+            container = await self._get_container(sandbox_id)
+            normalized_path = self.resolve_workspace_path(path)
 
-        tar_obj = await container.get_archive(normalized_path)
+            tar_obj = await container.get_archive(normalized_path)
 
-        content_bytes = b""
-        members = tar_obj.getmembers()
-        if members:
-            f = tar_obj.extractfile(members[0])
-            if f:
-                content_bytes = f.read()
+            content_bytes = b""
+            members = tar_obj.getmembers()
+            if members:
+                f = tar_obj.extractfile(members[0])
+                if f:
+                    content_bytes = f.read()
 
-        content, is_binary = self.encode_file_content(path, content_bytes)
+            content, is_binary = self.encode_file_content(path, content_bytes)
 
-        return FileContent(
-            path=path,
-            content=content,
-            type="file",
-            is_binary=is_binary,
-        )
+            return FileContent(
+                path=path,
+                content=content,
+                type="file",
+                is_binary=is_binary,
+            )
 
     async def create_pty(
         self,
@@ -390,46 +436,51 @@ class LocalDockerProvider(SandboxProvider):
         on_exit: PtyExitCallbackType,
         user_id: str = "",
     ) -> str:
-        # tmux for reconnect persistence; bare bash if missing. user_id unused (fixed container HOME).
-        container = await self._get_container(sandbox_id)
-        session_id = str(uuid.uuid4())
+        async with self._docker_operation("create Docker terminal"):
+            # tmux for reconnect persistence; bare bash if missing. user_id unused (fixed container HOME).
+            container = await self._get_container(sandbox_id)
+            session_id = str(uuid.uuid4())
 
-        cmd = [
-            "bash",
-            "-c",
-            self.build_pty_shell_command(tmux_session, "bash"),
-        ]
+            cmd = [
+                "bash",
+                "-c",
+                self.build_pty_shell_command(tmux_session, "bash"),
+            ]
 
-        # Root terminals keep $HOME as the start dir (dotfiles, existing
-        # behavior); worktree terminals must start inside the worktree.
-        workdir = self.resolve_workspace_path(cwd) if cwd else self.config.user_home
-        exec_obj = await container.exec(
-            cmd=cmd,
-            stdin=True,
-            tty=True,
-            environment={"TERM": TERMINAL_TYPE},
-            workdir=workdir,
-        )
-        stream = exec_obj.start()
-        # aiodocker creates the stream lazily — _init() opens the actual
-        # WebSocket to the Docker daemon. No public API exists for this.
-        await stream._init()
+            # Root terminals keep $HOME as the start dir (dotfiles, existing
+            # behavior); worktree terminals must start inside the worktree.
+            workdir = self.resolve_workspace_path(cwd) if cwd else self.config.user_home
+            exec_obj = await container.exec(
+                cmd=cmd,
+                stdin=True,
+                tty=True,
+                environment={"TERM": TERMINAL_TYPE},
+                workdir=workdir,
+            )
+            stream = exec_obj.start()
+            # aiodocker creates the stream lazily — _init() opens the actual
+            # WebSocket to the Docker daemon. No public API exists for this.
+            await stream._init()
 
-        reader_task = asyncio.create_task(self._pty_reader(stream, on_data, on_exit))
-        self.register_pty_session(
-            sandbox_id,
-            session_id,
-            {
-                "exec": exec_obj,
-                "stream": stream,
-                "reader_task": reader_task,
-            },
-        )
+            reader_task = asyncio.create_task(
+                self._pty_reader(stream, on_data, on_exit)
+            )
+            self.register_pty_session(
+                sandbox_id,
+                session_id,
+                {
+                    "exec": exec_obj,
+                    "stream": stream,
+                    "reader_task": reader_task,
+                },
+            )
 
-        if rows > 0 and cols > 0:
-            await self.resize_pty(sandbox_id, session_id, PtySize(rows=rows, cols=cols))
+            if rows > 0 and cols > 0:
+                await self.resize_pty(
+                    sandbox_id, session_id, PtySize(rows=rows, cols=cols)
+                )
 
-        return session_id
+            return session_id
 
     async def _pty_reader(
         self,
@@ -457,11 +508,12 @@ class LocalDockerProvider(SandboxProvider):
         pty_id: str,
         data: bytes,
     ) -> None:
-        session = self.get_pty_session(sandbox_id, pty_id)
-        if not session:
-            return
+        async with self._docker_operation("send Docker terminal input"):
+            session = self.get_pty_session(sandbox_id, pty_id)
+            if not session:
+                return
 
-        await session["stream"].write_in(data)
+            await session["stream"].write_in(data)
 
     async def resize_pty(
         self,
@@ -469,36 +521,36 @@ class LocalDockerProvider(SandboxProvider):
         pty_id: str,
         size: PtySize,
     ) -> None:
-        # Docker rejects zero dimensions — clamp to at least 1.
-        session = self.get_pty_session(sandbox_id, pty_id)
-        if not session:
-            return
+        async with self._docker_operation("resize Docker terminal"):
+            # Docker rejects zero dimensions — clamp to at least 1.
+            session = self.get_pty_session(sandbox_id, pty_id)
+            if not session:
+                return
 
-        await session["exec"].resize(h=max(size.rows, 1), w=max(size.cols, 1))
+            await session["exec"].resize(h=max(size.rows, 1), w=max(size.cols, 1))
 
     async def kill_pty(
         self,
         sandbox_id: str,
         pty_id: str,
     ) -> None:
-        # Best-effort teardown — stream/container may already be gone.
         session = self.get_pty_session(sandbox_id, pty_id)
         if not session:
             return
 
-        reader_task = session["reader_task"]
-        reader_task.cancel()
         try:
-            await reader_task
-        except asyncio.CancelledError:
-            pass
-
-        try:
-            await session["stream"].close()
-        except Exception:
-            pass
-
-        self.cleanup_pty_session_tracking(sandbox_id, pty_id)
+            reader_task = session["reader_task"]
+            reader_task.cancel()
+            try:
+                await reader_task
+            except asyncio.CancelledError:
+                pass
+        finally:
+            try:
+                await session["stream"].close()
+            except Exception:
+                pass
+            self.cleanup_pty_session_tracking(sandbox_id, pty_id)
 
     async def cleanup(self) -> None:
         await super().cleanup()

--- a/backend/requirements.lock
+++ b/backend/requirements.lock
@@ -7,7 +7,9 @@ aiodocker==0.24.0
 aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.3
-    # via aiodocker
+    # via
+    #   -r backend/requirements.txt
+    #   aiodocker
 aiosignal==1.4.0
     # via aiohttp
 aiosmtplib==5.1.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,6 +15,7 @@ markupsafe
 python-multipart
 starlette
 aiodocker>=0.22.0
+aiohttp>=3.13,<4.0
 agent-client-protocol==0.12.0
 sqladmin[full]
 httpx

--- a/backend/tests/test_sandbox.py
+++ b/backend/tests/test_sandbox.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiodocker.exceptions import DockerError
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm.attributes import flag_modified
@@ -87,6 +88,74 @@ async def test_docker_sandbox_chowns_only_managed_workspace(
 
     container.exec.assert_not_awaited()
     collect_exec_output.assert_not_awaited()
+
+
+async def test_docker_sandbox_reports_daemon_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LocalDockerProvider(DockerConfig())
+    docker = MagicMock()
+    docker.containers.create_or_replace = AsyncMock(
+        side_effect=DockerError(900, {"message": "Cannot connect to Docker Engine"})
+    )
+    monkeypatch.setattr(provider, "_get_docker", AsyncMock(return_value=docker))
+
+    with pytest.raises(SandboxException) as exc_info:
+        await provider.create_sandbox()
+
+    assert exc_info.value.status_code == 502
+    assert "is Docker running?" in exc_info.value.message
+    assert "Cannot connect to Docker Engine" in exc_info.value.message
+
+
+async def test_docker_sandbox_reports_constructor_connection_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LocalDockerProvider(DockerConfig())
+    monkeypatch.setattr(
+        "app.services.sandbox_providers.docker_provider.aiodocker.Docker",
+        MagicMock(side_effect=ValueError("Missing valid docker_host")),
+    )
+
+    with pytest.raises(SandboxException) as exc_info:
+        await provider.create_sandbox()
+
+    assert exc_info.value.status_code == 502
+    assert "is Docker running?" in exc_info.value.message
+    assert "Missing valid docker_host" in exc_info.value.message
+
+
+async def test_docker_sandbox_error_hint_is_limited_to_connectivity_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = LocalDockerProvider(DockerConfig())
+    docker = MagicMock()
+    docker.containers.create_or_replace = AsyncMock(
+        side_effect=DockerError(404, {"message": "No such image"})
+    )
+    monkeypatch.setattr(provider, "_get_docker", AsyncMock(return_value=docker))
+
+    with pytest.raises(SandboxException) as exc_info:
+        await provider.create_sandbox()
+
+    assert exc_info.value.status_code == 502
+    assert "is Docker running?" not in exc_info.value.message
+    assert "No such image" in exc_info.value.message
+
+
+async def test_delete_docker_sandbox_continues_after_stop_error() -> None:
+    provider = LocalDockerProvider(DockerConfig())
+    container = MagicMock()
+    container.stop = AsyncMock(
+        side_effect=DockerError(500, {"message": "failed to stop"})
+    )
+    container.delete = AsyncMock()
+    provider._containers["sandbox-1"] = container
+
+    await provider.delete_sandbox("sandbox-1")
+
+    container.delete.assert_awaited_once_with(force=True)
+    assert "sandbox-1" not in provider._containers
 
 
 @pytest.mark.parametrize("base_ref", ["main", "feat/api-keys", "release-1.2"])

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -41,6 +41,7 @@ import {
   resolveChatClient,
   resolveSandboxClient,
 } from './api';
+import { NetworkError } from '@/types/errors.types';
 
 const json = (body: unknown, status = 200, statusText?: string) =>
   new Response(body == null ? '' : JSON.stringify(body), { status, statusText });
@@ -95,6 +96,19 @@ describe('APIClient success + error shaping', () => {
     await expect(apiClient.get('/thing')).rejects.toMatchObject({
       message: 'HTTP error! status: 503',
     });
+  });
+
+  it('converts fetch rejections to NetworkError', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('Load failed'));
+
+    await expect(apiClient.get('/thing')).rejects.toBeInstanceOf(NetworkError);
+  });
+
+  it('rethrows fetch aborts unchanged', async () => {
+    const error = new DOMException('The operation was aborted', 'AbortError');
+    fetchMock.mockRejectedValueOnce(error);
+
+    await expect(apiClient.get('/thing')).rejects.toBe(error);
   });
 });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,7 @@ import { authStorage, cloudAuthStorage } from '@/utils/storage';
 import { invalidateSessionAndRedirect } from '@/utils/authSession';
 import { useCloudSettingsStore } from '@/store/cloudSettingsStore';
 import { isCloudChat, isCloudSandbox, clearCloudOrigins } from '@/utils/chatOrigin';
+import { NetworkError } from '@/types/errors.types';
 
 type RequestMethod = 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
 
@@ -226,7 +227,15 @@ class APIClient {
       config.body = formData;
     }
 
-    const response = await fetch(`${this.baseURL}${endpoint}`, config);
+    let response: Response;
+    try {
+      response = await fetch(`${this.baseURL}${endpoint}`, config);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        throw error;
+      }
+      throw new NetworkError();
+    }
 
     if (response.status === 401 && !isRetry && !endpoint.includes('/auth/jwt/')) {
       const hasRefreshToken = !!this.auth.getRefreshToken();

--- a/frontend/src/services/base/BaseService.test.ts
+++ b/frontend/src/services/base/BaseService.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { NetworkError, ServiceError } from './ServiceError';
+import { serviceCall } from './BaseService';
+
+describe('serviceCall', () => {
+  it('passes NetworkError through unchanged', async () => {
+    const error = new NetworkError();
+    const request = () => Promise.reject(error);
+
+    await expect(serviceCall(request, { maxRetries: 0 })).rejects.toBe(error);
+  });
+
+  it('does not retry a 502 response', async () => {
+    const request = vi.fn(() =>
+      Promise.reject(new ServiceError('Docker unavailable', undefined, {}, 502)),
+    );
+
+    await expect(serviceCall(request)).rejects.toMatchObject({ status: 502 });
+    expect(request).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/services/base/BaseService.ts
+++ b/frontend/src/services/base/BaseService.ts
@@ -1,4 +1,4 @@
-import { ServiceError, AuthenticationError, NetworkError } from './ServiceError';
+import { ServiceError, AuthenticationError } from './ServiceError';
 import { invalidateSessionAndRedirect } from '@/utils/authSession';
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -106,10 +106,6 @@ function handleServiceError(error: unknown): ServiceError {
 
     if (status === 401 || error.message.includes('401') || error.message.includes('Unauthorized')) {
       return new AuthenticationError();
-    }
-
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      return new NetworkError();
     }
 
     const statusMatch = error.message.match(/status:\s*(\d+)/);

--- a/frontend/src/store/messageQueueStore.test.ts
+++ b/frontend/src/store/messageQueueStore.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useMessageQueueStore, EMPTY_QUEUE } from './messageQueueStore';
 import { queueService } from '@/services/queueService';
 import type { LocalQueuedMessage } from '@/types/queue.types';
+import { NetworkError } from '@/types/errors.types';
 
 vi.mock('@/services/queueService', () => ({
   queueService: {
@@ -55,7 +56,7 @@ describe('queueMessage', () => {
   });
 
   it('keeps the unsynced local message on a network error and returns the temp id', async () => {
-    svc.queueMessage.mockRejectedValue(new TypeError('Failed to fetch'));
+    svc.queueMessage.mockRejectedValue(new NetworkError());
     const returned = await useMessageQueueStore.getState().queueMessage('c1', 'hello', 'gpt-5');
 
     const queue = queueOf('c1');

--- a/frontend/src/store/messageQueueStore.ts
+++ b/frontend/src/store/messageQueueStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { LocalQueuedMessage, QueueMessageOptions } from '@/types/queue.types';
 import { queueService } from '@/services/queueService';
 import { DEFAULT_PERSONA, DEFAULT_PERMISSION_MODE } from '@/store/chatSettingsStore';
+import { NetworkError } from '@/types/errors.types';
 
 export const EMPTY_QUEUE: LocalQueuedMessage[] = [];
 
@@ -83,10 +84,7 @@ export const useMessageQueueStore = create<MessageQueueState>((set, get) => ({
 
       return result.id;
     } catch (error) {
-      const isNetworkError =
-        error instanceof TypeError || (error instanceof Error && error.message.includes('network'));
-
-      if (!isNetworkError) {
+      if (!(error instanceof NetworkError)) {
         get().removeLocalOnly(chatId, tempId);
         throw error;
       }

--- a/frontend/src/types/errors.types.ts
+++ b/frontend/src/types/errors.types.ts
@@ -24,9 +24,7 @@ export class ServiceError extends Error {
   static isRetryable(error: ServiceError): boolean {
     if (!error.status) return false;
 
-    return (
-      error.status === 503 || error.status === 504 || (error.status >= 500 && error.status < 600)
-    );
+    return error.status === 500 || error.status === 503 || error.status === 504;
   }
 }
 


### PR DESCRIPTION
## Problem

Creating a workspace with the Docker provider while the Docker daemon is not running showed a useless toast — WebKit's raw `Load failed` (Tauri desktop webview) or the generic `An internal server error occurred` — instead of the actual cause.

Two failures stacked:
- **Backend**: `LocalDockerProvider` only wrapped the aiodocker *constructor*; the first real daemon call (`create_or_replace`/`start`) raised an unwrapped `DockerError` that hit the global exception handler as an opaque 500. The real message went only to the logs.
- **Frontend**: `handleServiceError` only recognized Chromium's `'Failed to fetch'` `TypeError`, so WebKit's `'Load failed'` reached the toast verbatim — and the opaque 500 was auto-retried 4× before showing anything.

## Changes

### Backend
- `_docker_operation` context manager in `docker_provider.py` maps `DockerError` / `aiohttp.ClientError` / `asyncio.TimeoutError` from all provider operations to a structured `SandboxException(502)` carrying the underlying error text, which the existing global handler renders as JSON.
- The "is Docker running?" hint is added only for connectivity-class failures: the constructor's no-socket `ValueError` (typical macOS "Docker Desktop stopped" case), `ClientError`/timeout, and aiodocker's `DockerError(900)` connection wrap. Daemon-replied errors (404 no-such-image, 409, …) surface their own message without the misleading hint.
- Teardown paths stay best-effort: `delete_sandbox` remains idempotent (stop failure still force-deletes; container cache popped in `finally`), `kill_pty` always cleans session tracking, `connect_sandbox` drops stale cached containers on 404.

### Frontend
- Network-level fetch failures are classified **at the origin**: the central `APIClient` fetch call throws a typed `NetworkError` on rejection (rethrowing `AbortError` unchanged) instead of string-matching browser-specific `TypeError` messages downstream. The brittle per-browser string set is gone.
- `messageQueueStore` keys its keep-queued-on-network-failure logic on `instanceof NetworkError` instead of `TypeError`/substring guessing.
- `ServiceError.isRetryable` narrowed to {500, 503, 504} so the Docker 502 surfaces immediately instead of after 4 attempts.

Result: daemon down now shows e.g. `Failed to create Docker sandbox — is Docker running? (Cannot connect to Docker Engine via unix:///var/run/docker.sock)`; backend unreachable shows `Network request failed`.

## Testing
- Backend: `pytest tests/ -q` — 398 passed; new tests cover constructor failure, DockerError 900 vs 404 hint gating, and delete-after-stop-failure idempotency.
- Frontend: `vitest run src/lib src/services` (47) + `messageQueueStore.test.ts` (21) — all passing; new tests cover fetch rejection → `NetworkError`, `AbortError` pass-through, and 502 non-retry. `tsc`, `eslint`, `prettier`, `ruff check`/`format` clean.
- Reviewed by two independent reviewers, including live-daemon reproduction of the failure paths.