### PR TITLE
Wrap long unbroken strings inside toasts

### DIFF
--- a/frontend/src/styles/app.scss
+++ b/frontend/src/styles/app.scss
@@ -85,6 +85,8 @@
   background-color: var(--theme-surface-secondary) !important;
   color: var(--theme-text-primary) !important;
   box-shadow: var(--shadow-medium) !important;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 // @mention / /command highlight (see HighlightedText.MENTION_PILL_CLASSNAME)


### PR DESCRIPTION
## Problem
Toast messages containing long unbroken tokens (e.g. `unix:///Users/michaelnagy/.docker/run/docker.sock`) overflow the toast container horizontally — the toast is capped at `maxWidth: 420px` in `frontend/src/config/toaster.ts`, but `.app-toast` set no word-wrapping.

## Fix
Add `overflow-wrap: anywhere` (plus `word-break: break-word` as a WebKit fallback) to `.app-toast` in `frontend/src/styles/app.scss`. Both properties inherit, so they reach react-hot-toast's inner message div without `!important` or config changes.

## Validation
- `npm run lint` — passed
- `npm run format:check` — passed