### PR TITLE
Underline file-link pills at rest to signal clickability

### DIFF
--- a/frontend/src/components/ui/markdown/markdownComponents.module.scss
+++ b/frontend/src/components/ui/markdown/markdownComponents.module.scss
@@ -175,12 +175,8 @@
   border-radius: var(--radius-md);
   padding: var(--space-0-5) var(--space-1);
   background-color: var(--theme-surface-secondary);
-  text-decoration: none;
+  text-decoration: underline;
   cursor: pointer;
-
-  @include responsive.hover {
-    text-decoration: underline;
-  }
 }
 
 .img {


### PR DESCRIPTION
File-link pills in chat (from #935) showed no clickable affordance until hover. `.file-link` now has `text-decoration: underline` at rest — same `--theme-text-primary` color as regular links — and the now-redundant hover-only underline rule is removed. Underline over `border-bottom` so the line sits under the glyphs inside the padded/rounded chip rather than on its outer edge; hover color shift via `.link` unchanged.

Lint clean; verified visually in the running app.