### PR TITLE
Show antigravity read tools as complete on arrival

### DIFF
--- a/frontend/src/components/chat/tools/antigravity/ReadTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/ReadTool.tsx
@@ -11,11 +11,13 @@ export const ReadTool = memo(function ReadTool({ tool }: { tool: ToolAggregate }
   const input = tool.input as AntigravityReadInput | undefined;
   const filePath = input?.AbsolutePath ?? input?.absolute_path ?? '';
   const label = filePath ? extractFilename(filePath) : humanizeToolTitle(tool.title) || 'file';
+  // The server batches or omits read completions even though reads finish immediately.
+  const displayStatus = tool.status === 'started' ? 'completed' : tool.status;
 
   return (
     <ToolCard
       icon={<FileSearch className={styles.icon} />}
-      status={tool.status}
+      status={displayStatus}
       title={(status) => {
         switch (status) {
           case 'completed':
@@ -26,7 +28,6 @@ export const ReadTool = memo(function ReadTool({ tool }: { tool: ToolAggregate }
             return `Reading ${label}`;
         }
       }}
-      loadingContent="Reading file..."
       error={tool.error}
       actions={filePath ? <OpenInEditorButton filePath={filePath} /> : null}
     >


### PR DESCRIPTION
Fixes read-tool cards stuck on "Reading file..." indefinitely.

**Diagnosis** (from stored chat data + live probes): antigravity's `view_file` reads (toolCallId `call_*`) come from a different internal subsystem than execute/search (`{sessionId}:N`), and the server **batches their completions until end of turn** — or never sends them when a turn errors mid-way (observed in a real chat: a failed `pytest` execute caused an error sweep, and every read after the retry stayed `started` forever). Execute/search complete inline and are unaffected.

**Fix**: reads are instantaneous server-side and their completions never carry data (no output/content — that's also why read cards show no file body; the server keeps contents internal). So `ReadTool` now renders `started` as completed immediately — no spinner, no loading row. Real `failed` statuses still render as failures.

Typecheck, lint, build pass.