### PR TITLE
Show failed status icon for non-zero exit codes in antigravity execute cards

### DIFF
--- a/frontend/src/components/chat/tools/antigravity/ExecuteTool.tsx
+++ b/frontend/src/components/chat/tools/antigravity/ExecuteTool.tsx
@@ -15,18 +15,19 @@ export const ExecuteTool = memo(function ExecuteTool({ tool }: { tool: ToolAggre
   const output = result?.combinedOutput ?? result?.formatted_output ?? '';
   const exitCode = result?.exitCode ?? result?.exit_code;
   const failed = typeof exitCode === 'number' && exitCode !== 0;
+  const displayStatus = tool.status === 'completed' && failed ? 'failed' : tool.status;
   const label = command || 'command';
 
   return (
     <ToolCard
       icon={<Terminal className={styles.icon} />}
-      status={tool.status}
+      status={displayStatus}
       title={(status) => {
         switch (status) {
           case 'completed':
-            return failed ? `Failed (exit ${exitCode}): ${label}` : `Ran: ${label}`;
+            return `Ran: ${label}`;
           case 'failed':
-            return `Failed: ${label}`;
+            return failed ? `Failed (exit ${exitCode}): ${label}` : `Failed: ${label}`;
           default:
             return `Running: ${label}`;
         }


### PR DESCRIPTION
Small follow-up to #939. The antigravity server marks an execute tool call `completed` when it successfully *ran* the command, even if the command itself exited non-zero — so cards showed a green checkmark next to a "Failed (exit 127)" title. The card status is now derived from the exit code: completed + non-zero exit renders the failed indicator, with the exit code kept in the title. In-flight and genuine server statuses unchanged. Typecheck, lint, build pass.