### PR TITLE
Add opt-in browser automation via browser-use MCP in Docker sandboxes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,8 @@ VITE_WS_URL=/api/v1/ws
 # credentials to configure.
 # AGENTROVE_MCP_ENABLED=true
 # AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS=604800
+# Optional: enable browser-use in Docker sandboxes; unavailable in host mode.
+# AGENTROVE_BROWSER_MCP_ENABLED=true
 
 # Production / Coolify (docker-compose-production.yml)
 # APP_URL=https://yourdomain.com
@@ -78,6 +80,8 @@ VITE_WS_URL=/api/v1/ws
 # --- Docker sandbox limits ---
 # DOCKER_HOST=
 # DOCKER_MEM_LIMIT=4g
+# Shared memory available to Chromium and other sandbox processes.
+# DOCKER_SHM_SIZE=2g
 # DOCKER_CPU_PERIOD=100000
 # DOCKER_CPU_QUOTA=200000
 # DOCKER_PIDS_LIMIT=512

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,8 @@ VITE_WS_URL=/api/v1/ws
 # AGENTROVE_MCP_ENABLED=true
 # AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS=604800
 # Optional: enable browser-use in Docker sandboxes; unavailable in host mode.
+# Browser tools are unavailable in arm64 sandbox images.
+# Existing containers keep the old image; recreate workspaces after upgrading so browser tools take effect.
 # AGENTROVE_BROWSER_MCP_ENABLED=true
 
 # Production / Coolify (docker-compose-production.yml)
@@ -80,7 +82,7 @@ VITE_WS_URL=/api/v1/ws
 # --- Docker sandbox limits ---
 # DOCKER_HOST=
 # DOCKER_MEM_LIMIT=4g
-# Shared memory available to Chromium and other sandbox processes.
+# Optional shared-memory increase for browser and GUI workloads in the sandbox.
 # DOCKER_SHM_SIZE=2g
 # DOCKER_CPU_PERIOD=100000
 # DOCKER_CPU_QUOTA=200000

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -153,12 +153,14 @@ class Settings(BaseSettings):
     # Opt-in stdio MCP server (mcp-server/server.py); calls this backend at
     # BASE_URL with a per-user access token minted at session spawn.
     AGENTROVE_MCP_ENABLED: bool = False
+    AGENTROVE_BROWSER_MCP_ENABLED: bool = False
     AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS: int = 604800
 
     DOCKER_IMAGE: str = "ghcr.io/mng-dev-ai/agentrove-sandbox:latest"
     DOCKER_NETWORK: str = "agentrove-sandbox-net"
     DOCKER_HOST: str | None = None
     DOCKER_MEM_LIMIT: str = "4g"
+    DOCKER_SHM_SIZE: str = "2g"
     DOCKER_CPU_PERIOD: int = 100000
     DOCKER_CPU_QUOTA: int = 200000
     DOCKER_PIDS_LIMIT: int = 512

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -160,7 +160,7 @@ class Settings(BaseSettings):
     DOCKER_NETWORK: str = "agentrove-sandbox-net"
     DOCKER_HOST: str | None = None
     DOCKER_MEM_LIMIT: str = "4g"
-    DOCKER_SHM_SIZE: str = "2g"
+    DOCKER_SHM_SIZE: str = ""
     DOCKER_CPU_PERIOD: int = 100000
     DOCKER_CPU_QUOTA: int = 200000
     DOCKER_PIDS_LIMIT: int = 512

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -495,7 +495,10 @@ class AgentService:
                     "env": env,
                 }
             )
-        if settings.AGENTROVE_BROWSER_MCP_ENABLED:
+        if (
+            settings.AGENTROVE_BROWSER_MCP_ENABLED
+            and sandbox_provider is SandboxProviderType.DOCKER
+        ):
             browser_env = {"BROWSER_USE_HEADLESS": "true"}
             servers.append(
                 {

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -464,36 +464,48 @@ class AgentService:
     def _build_mcp_server_configs(
         chat_id: str | None, user_id: str, sandbox_provider: SandboxProviderType
     ) -> list[dict[str, Any]]:
-        # Opt-in: hand the agent Agentrove's own chat tools over a stdio MCP server.
-        if not settings.AGENTROVE_MCP_ENABLED:
-            return []
-        if sandbox_provider is SandboxProviderType.HOST:
-            # Host-provider agents share this process's network namespace, but the
-            # public BASE_URL is often unreachable from inside the deployment
-            # (hairpin NAT), so point the MCP server at the local uvicorn instead.
-            # Web mode listens on ${PORT:-8080}; desktop derives its port from a
-            # loopback BASE_URL (desktop/entry.py).
-            port = os.environ.get("PORT") or urlparse(settings.BASE_URL).port or 8080
-            api_base = f"http://127.0.0.1:{port}"
-        else:
-            api_base = settings.BASE_URL
-        env = {
-            "AGENTROVE_API_URL": f"{api_base}{settings.API_V1_STR}",
-            "AGENTROVE_ACCESS_TOKEN": create_mcp_access_token(user_id),
-        }
-        # The chat this session runs in — lets the agent create sub-threads under it
-        if chat_id:
-            env["AGENTROVE_CURRENT_CHAT_ID"] = chat_id
-        return [
-            {
-                "name": "agentrove",
-                # Spawn with the backend's own interpreter (the bundled sidecar
-                # Python, which ships mcp+httpx) — avoids PATH/version surprises
-                "command": sys.executable,
-                "args": [str(MCP_SERVER_PATH)],
-                "env": env,
+        servers: list[dict[str, Any]] = []
+        if settings.AGENTROVE_MCP_ENABLED:
+            if sandbox_provider is SandboxProviderType.HOST:
+                # Host-provider agents share this process's network namespace, but the
+                # public BASE_URL is often unreachable from inside the deployment
+                # (hairpin NAT), so point the MCP server at the local uvicorn instead.
+                # Web mode listens on ${PORT:-8080}; desktop derives its port from a
+                # loopback BASE_URL (desktop/entry.py).
+                port = (
+                    os.environ.get("PORT") or urlparse(settings.BASE_URL).port or 8080
+                )
+                api_base = f"http://127.0.0.1:{port}"
+            else:
+                api_base = settings.BASE_URL
+            env = {
+                "AGENTROVE_API_URL": f"{api_base}{settings.API_V1_STR}",
+                "AGENTROVE_ACCESS_TOKEN": create_mcp_access_token(user_id),
             }
-        ]
+            # The chat this session runs in — lets the agent create sub-threads under it
+            if chat_id:
+                env["AGENTROVE_CURRENT_CHAT_ID"] = chat_id
+            servers.append(
+                {
+                    "name": "agentrove",
+                    # Spawn with the backend's own interpreter (the bundled sidecar
+                    # Python, which ships mcp+httpx) — avoids PATH/version surprises
+                    "command": sys.executable,
+                    "args": [str(MCP_SERVER_PATH)],
+                    "env": env,
+                }
+            )
+        if settings.AGENTROVE_BROWSER_MCP_ENABLED:
+            browser_env = {"BROWSER_USE_HEADLESS": "true"}
+            servers.append(
+                {
+                    "name": "browser",
+                    "command": "browser-use",
+                    "args": ["--mcp"],
+                    "env": browser_env,
+                }
+            )
+        return servers
 
     async def _build_acp_config(
         self,

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -74,6 +74,7 @@ class SandboxProvider:
                     network=settings.DOCKER_NETWORK,
                     host=settings.DOCKER_HOST,
                     mem_limit=settings.DOCKER_MEM_LIMIT,
+                    shm_size=settings.DOCKER_SHM_SIZE,
                     cpu_period=settings.DOCKER_CPU_PERIOD,
                     cpu_quota=settings.DOCKER_CPU_QUOTA,
                     pids_limit=settings.DOCKER_PIDS_LIMIT,

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -43,6 +43,7 @@ class DockerConfig:
     host: str | None = None
     user_home: str = "/home/user"
     mem_limit: str = ""
+    shm_size: str = ""
     cpu_period: int = 0
     cpu_quota: int = 0
     pids_limit: int = 0
@@ -96,15 +97,14 @@ class LocalDockerProvider(SandboxProvider):
             ) from e
 
     @staticmethod
-    def _parse_mem_limit(mem_str: str) -> int:
-        # "4g"/"512m" → bytes for Docker Memory.
-        mem_str = mem_str.strip().lower()
-        if not mem_str:
+    def _parse_byte_size(size: str) -> int:
+        size = size.strip().lower()
+        if not size:
             return 0
         multipliers = {"k": 1024, "m": 1024**2, "g": 1024**3}
-        if mem_str[-1] in multipliers:
-            return int(mem_str[:-1]) * multipliers[mem_str[-1]]
-        return int(mem_str)
+        if size[-1] in multipliers:
+            return int(size[:-1]) * multipliers[size[-1]]
+        return int(size)
 
     async def _get_container(self, sandbox_id: str) -> Any:
         # Reconnect if uncached; restart if the container has exited.
@@ -132,7 +132,9 @@ class LocalDockerProvider(SandboxProvider):
         }
 
         if self.config.mem_limit:
-            host_config["Memory"] = self._parse_mem_limit(self.config.mem_limit)
+            host_config["Memory"] = self._parse_byte_size(self.config.mem_limit)
+        if self.config.shm_size:
+            host_config["ShmSize"] = self._parse_byte_size(self.config.shm_size)
         if self.config.cpu_period > 0:
             host_config["CpuPeriod"] = self.config.cpu_period
         if self.config.cpu_quota > 0:

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -101,6 +101,7 @@ class LocalDockerProvider(SandboxProvider):
         size = size.strip().lower()
         if not size:
             return 0
+        size = size.removesuffix("b")
         multipliers = {"k": 1024, "m": 1024**2, "g": 1024**3}
         if size[-1] in multipliers:
             return int(size[:-1]) * multipliers[size[-1]]

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -52,6 +52,28 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+      amd64) \
+        curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o /tmp/google-chrome.deb; \
+        apt-get update; \
+        apt-get install -y /tmp/google-chrome.deb fonts-liberation fonts-noto-color-emoji; \
+        google-chrome --version; \
+        rm /tmp/google-chrome.deb \
+        ;; \
+      arm64) \
+        apt-get update; \
+        apt-get install -y debian-archive-keyring; \
+        echo "deb [signed-by=/usr/share/keyrings/debian-archive-bookworm-stable.gpg] http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/debian-bookworm.list; \
+        printf 'Package: chromium chromium-common chromium-sandbox\nPin: release n=bookworm\nPin-Priority: 1001\n' > /etc/apt/preferences.d/chromium; \
+        apt-get update; \
+        apt-get install -y chromium fonts-liberation fonts-noto-color-emoji; \
+        chromium --version \
+        ;; \
+      *) exit 1 ;; \
+    esac; \
+    rm -rf /var/lib/apt/lists/*
+
 RUN curl -fsSL https://get.docker.com | sh && \
     mkdir -p /etc/docker && \
     echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
@@ -132,6 +154,9 @@ RUN set -eux; \
 RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \
     uv
+
+RUN uv tool install --python python3.12 'browser-use[cli]==0.13.8' && \
+    browser-use --version
 
 RUN echo '#!/bin/bash\nexec echo $GITHUB_TOKEN' > /home/user/.git-askpass.sh && \
     chmod +x /home/user/.git-askpass.sh

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -62,13 +62,7 @@ RUN set -eux; \
         rm /tmp/google-chrome.deb \
         ;; \
       arm64) \
-        apt-get update; \
-        apt-get install -y debian-archive-keyring; \
-        echo "deb [signed-by=/usr/share/keyrings/debian-archive-bookworm-stable.gpg] http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list.d/debian-bookworm.list; \
-        printf 'Package: chromium chromium-common chromium-sandbox\nPin: release n=bookworm\nPin-Priority: 1001\n' > /etc/apt/preferences.d/chromium; \
-        apt-get update; \
-        apt-get install -y chromium fonts-liberation fonts-noto-color-emoji; \
-        chromium --version \
+        : \
         ;; \
       *) exit 1 ;; \
     esac; \
@@ -155,8 +149,17 @@ RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \
     uv
 
-RUN uv tool install --python python3.12 'browser-use[cli]==0.13.8' && \
-    browser-use --version
+RUN set -eux; \
+    case "$(dpkg --print-architecture)" in \
+      amd64) \
+        uv tool install --python python3.12 'browser-use[cli]==0.13.8'; \
+        browser-use --version \
+        ;; \
+      arm64) \
+        : \
+        ;; \
+      *) exit 1 ;; \
+    esac
 
 RUN echo '#!/bin/bash\nexec echo $GITHUB_TOKEN' > /home/user/.git-askpass.sh && \
     chmod +x /home/user/.git-askpass.sh


### PR DESCRIPTION
## What

Gives agent chats browser-automation tools by injecting the official [browser-use](https://github.com/browser-use/browser-use) stdio MCP server (`browser-use --mcp`) into Docker-sandbox sessions, behind a new opt-in flag.

- **`sandbox/docker/Dockerfile`**: installs Google Chrome stable + fonts and `browser-use[cli]==0.13.8` (amd64 only; arm64 ships no browser — see limitations). Build verifies `google-chrome --version` and the `browser-use` entrypoint.
- **`AgentService._build_mcp_server_configs`**: when `AGENTROVE_BROWSER_MCP_ENABLED=true` **and** the sandbox provider is Docker, appends a `browser` stdio MCP server with `BROWSER_USE_HEADLESS=true`. Host-mode sessions (including the forced-HOST `_generate_text` path used for titles/commit messages) are excluded. The existing `agentrove` MCP path is behavior-identical (refactored from early-return to accumulator).
- **Sandbox provider plumbing**: new optional `DOCKER_SHM_SIZE` setting (default empty = Docker's default) passed through to the container's `ShmSize`; `_parse_mem_limit` generalized to `_parse_byte_size`, now also accepting Docker-style suffixes (`2gb`, `512MB`).
- **`.env.example`**: documents both settings, the arm64 limitation, and that existing workspaces must be recreated after upgrading the sandbox image.

browser-use's direct tools (navigate, click, type, get_state, screenshot, tabs) run without any LLM API key — the chat's own agent does the planning.

## Why this shape

Running the browser inside the per-workspace sandbox container reuses the existing isolation and resource limits (no shared browser service, no new compose service), and the stdio MCP server is browser-use's officially supported self-host surface.

## Review

Two independent blind review rounds. Round 1 caught and fixed: an arm64 Dockerfile branch that could not build (missing Debian bookworm keyring) and would have swapped glibc via a cross-distro apt pin, plus the host-mode injection leak. Round 2 approved after end-to-end verification (real stdio JSON-RPC `initialize`/`tools/list`/`browser_navigate` against the built image); its remaining findings (arm64 fail-fast, shm default, byte-parser spelling) are fixed in the second commit.

## Validation

- `cd backend && uv run pytest tests/test_acp.py tests/test_sandbox.py` — 138 passed
- `cd backend && uv run ruff format --check . && uv run ruff check .` — clean
- `docker build -f sandbox/docker/Dockerfile .` — passes (amd64); in-container smoke test: `browser-use` on PATH for user `user`, Chrome 152 renders headlessly

## Known limitations

- **arm64**: no browser installed (Ubuntu 22.04 has no snap-free arm64 Chromium; Debian's needs glibc 2.36). Enabling the flag on an arm64 sandbox yields a fast MCP spawn failure rather than working tools.
- **No domain allowlist**: agents can browse anywhere; browser-use supports `BROWSER_USE_ALLOWED_DOMAINS` if wanted later.
- **Image size**: the Chrome + browser-use layers add ~1.1 GB to the amd64 sandbox image, paid even when the flag is off.
- Existing sandbox containers keep the old image — workspaces must be recreated to get the browser tools.