### PR TITLE
Switch browser MCP to browser-use Cloud; slim sandbox image; add host/desktop support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,10 +22,7 @@ VITE_WS_URL=/api/v1/ws
 # credentials to configure.
 # AGENTROVE_MCP_ENABLED=true
 # AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS=604800
-# Optional: enable browser-use in Docker sandboxes; unavailable in host mode.
-# Browser tools are unavailable in arm64 sandbox images.
-# Existing containers keep the old image; recreate workspaces after upgrading so browser tools take effect.
-# AGENTROVE_BROWSER_MCP_ENABLED=true
+# BROWSER_USE_API_KEY=bu_...
 
 # Production / Coolify (docker-compose-production.yml)
 # APP_URL=https://yourdomain.com
@@ -82,8 +79,6 @@ VITE_WS_URL=/api/v1/ws
 # --- Docker sandbox limits ---
 # DOCKER_HOST=
 # DOCKER_MEM_LIMIT=4g
-# Optional shared-memory increase for browser and GUI workloads in the sandbox.
-# DOCKER_SHM_SIZE=2g
 # DOCKER_CPU_PERIOD=100000
 # DOCKER_CPU_QUOTA=200000
 # DOCKER_PIDS_LIMIT=512

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -87,7 +87,14 @@ COPY backend/requirements.lock .
 
 RUN /root/.local/bin/uv pip install --system --no-cache -r requirements.lock
 
+RUN /root/.local/bin/uv venv /app/browser-use --python python3.12 && \
+    /root/.local/bin/uv pip install --python /app/browser-use/bin/python \
+    'browser-use[cli]==0.13.8'
+
 COPY backend/ /app/
+
+RUN /app/browser-use/bin/python -c \
+    "from app.browser_mcp_cloud import CloudBrowserUseServer"
 
 # Agentrove chat MCP server (mcp-server/server.py) lives at the repo root, not
 # under backend/. The backend spawns it from /app/mcp-server/ (see MCP_SERVER_PATH

--- a/backend/app/browser_mcp_cloud.py
+++ b/backend/app/browser_mcp_cloud.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import asyncio
+import os
+import sys
+
+from browser_use.mcp.server import BrowserUseServer
+
+
+class CloudBrowserUseServer(BrowserUseServer):
+    async def _init_browser_session(
+        self, allowed_domains: list[str] | None = None, **kwargs
+    ):
+        # The upstream MCP server otherwise always creates a local browser profile.
+        kwargs["use_cloud"] = True
+        await super()._init_browser_session(allowed_domains=allowed_domains, **kwargs)
+
+
+async def main() -> None:
+    if not os.environ.get("BROWSER_USE_API_KEY"):
+        print(
+            "BROWSER_USE_API_KEY is required for cloud browser tools", file=sys.stderr
+        )
+        raise SystemExit(1)
+
+    server = CloudBrowserUseServer()
+    try:
+        await server.run()
+    finally:
+        # Upstream keep_alive=True requires an explicit kill to stop cloud billing.
+        if server.browser_session is not None:
+            try:
+                await server.browser_session.kill()
+            except Exception as exc:
+                print(f"Failed to stop cloud browser session: {exc}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -153,14 +153,13 @@ class Settings(BaseSettings):
     # Opt-in stdio MCP server (mcp-server/server.py); calls this backend at
     # BASE_URL with a per-user access token minted at session spawn.
     AGENTROVE_MCP_ENABLED: bool = False
-    AGENTROVE_BROWSER_MCP_ENABLED: bool = False
+    BROWSER_USE_API_KEY: str = ""
     AGENTROVE_MCP_TOKEN_LIFETIME_SECONDS: int = 604800
 
     DOCKER_IMAGE: str = "ghcr.io/mng-dev-ai/agentrove-sandbox:latest"
     DOCKER_NETWORK: str = "agentrove-sandbox-net"
     DOCKER_HOST: str | None = None
     DOCKER_MEM_LIMIT: str = "4g"
-    DOCKER_SHM_SIZE: str = ""
     DOCKER_CPU_PERIOD: int = 100000
     DOCKER_CPU_QUOTA: int = 200000
     DOCKER_PIDS_LIMIT: int = 512

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -46,6 +46,10 @@ logger = logging.getLogger(__name__)
 # MCP server ships next to the backend (bundled into the sidecar by run_build.mjs),
 # so its path derives from this file: app/services/agent.py -> ../../mcp-server/server.py
 MCP_SERVER_PATH = Path(__file__).resolve().parents[2] / "mcp-server" / "server.py"
+BROWSER_MCP_CLOUD_PATH = Path(__file__).resolve().parents[1] / "browser_mcp_cloud.py"
+BROWSER_USE_PYTHON_PATH = (
+    BROWSER_MCP_CLOUD_PATH.parents[1] / "browser-use" / "bin" / "python"
+)
 
 
 class StreamResult:
@@ -495,17 +499,19 @@ class AgentService:
                     "env": env,
                 }
             )
-        if (
-            settings.AGENTROVE_BROWSER_MCP_ENABLED
-            and sandbox_provider is SandboxProviderType.DOCKER
-        ):
-            browser_env = {"BROWSER_USE_HEADLESS": "true"}
+        if chat_id and settings.BROWSER_USE_API_KEY:
+            if sandbox_provider is SandboxProviderType.DOCKER:
+                command = "/home/user/.local/share/uv/tools/browser-use/bin/python"
+                args = ["/home/user/browser_mcp_cloud.py"]
+            else:
+                command = str(BROWSER_USE_PYTHON_PATH)
+                args = [str(BROWSER_MCP_CLOUD_PATH)]
             servers.append(
                 {
                     "name": "browser",
-                    "command": "browser-use",
-                    "args": ["--mcp"],
-                    "env": browser_env,
+                    "command": command,
+                    "args": args,
+                    "env": {"BROWSER_USE_API_KEY": settings.BROWSER_USE_API_KEY},
                 }
             )
         return servers

--- a/backend/app/services/sandbox_providers/base.py
+++ b/backend/app/services/sandbox_providers/base.py
@@ -74,7 +74,6 @@ class SandboxProvider:
                     network=settings.DOCKER_NETWORK,
                     host=settings.DOCKER_HOST,
                     mem_limit=settings.DOCKER_MEM_LIMIT,
-                    shm_size=settings.DOCKER_SHM_SIZE,
                     cpu_period=settings.DOCKER_CPU_PERIOD,
                     cpu_quota=settings.DOCKER_CPU_QUOTA,
                     pids_limit=settings.DOCKER_PIDS_LIMIT,

--- a/backend/app/services/sandbox_providers/docker_provider.py
+++ b/backend/app/services/sandbox_providers/docker_provider.py
@@ -43,7 +43,6 @@ class DockerConfig:
     host: str | None = None
     user_home: str = "/home/user"
     mem_limit: str = ""
-    shm_size: str = ""
     cpu_period: int = 0
     cpu_quota: int = 0
     pids_limit: int = 0
@@ -134,8 +133,6 @@ class LocalDockerProvider(SandboxProvider):
 
         if self.config.mem_limit:
             host_config["Memory"] = self._parse_byte_size(self.config.mem_limit)
-        if self.config.shm_size:
-            host_config["ShmSize"] = self._parse_byte_size(self.config.shm_size)
         if self.config.cpu_period > 0:
             host_config["CpuPeriod"] = self.config.cpu_period
         if self.config.cpu_quota > 0:

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -24,6 +24,7 @@ const RELEASE_TAG = '20260211';
 const RIPGREP_VERSION = '14.1.1';
 const CLAUDE_AGENT_ACP_VERSION = '0.70.0';
 const CODEX_ACP_VERSION = '1.6.0';
+const BROWSER_USE_VERSION = '0.13.8';
 const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
 
 const platform = process.platform;
@@ -37,6 +38,8 @@ if (platform !== 'darwin' || !['arm64', 'x64'].includes(arch)) {
 const ARCH_TRIPLE = arch === 'arm64' ? 'aarch64-apple-darwin' : 'x86_64-apple-darwin';
 
 const pythonBin = join(sidecarDir, 'python', 'bin', 'python3');
+const browserUseDir = join(sidecarDir, 'browser-use');
+const browserUsePython = join(browserUseDir, 'bin', 'python');
 const nodeDir = join(sidecarDir, 'node');
 const nodeBin = join(nodeDir, 'bin', 'node');
 const npmBin = join(nodeDir, 'bin', 'npm');
@@ -49,6 +52,7 @@ const PYTHON_STAMP = `${PYTHON_VERSION}+${RELEASE_TAG}-${arch}-${platform}`;
 const NODE_STAMP = `${NODE_VERSION}-${arch}-${platform}`;
 const RG_STAMP = `${RIPGREP_VERSION}-${arch}-${platform}`;
 const ACP_STAMP = `${CLAUDE_AGENT_ACP_VERSION}-${CODEX_ACP_VERSION}-${NODE_STAMP}`;
+const BROWSER_USE_STAMP = `${BROWSER_USE_VERSION}-${PYTHON_STAMP}`;
 
 function stampPath(name) {
   return join(sidecarDir, `.${name}-stamp`);
@@ -197,6 +201,21 @@ function installPyDeps() {
   writeStamp('deps', depsStampValue());
 }
 
+function installBrowserUse() {
+  rmSync(browserUseDir, { recursive: true, force: true });
+  execFileSync(pythonBin, ['-m', 'venv', browserUseDir], { stdio: 'inherit' });
+  execFileSync(
+    browserUsePython,
+    [
+      '-m', 'pip', 'install', '-q',
+      '--disable-pip-version-check',
+      `browser-use[cli]==${BROWSER_USE_VERSION}`,
+    ],
+    { stdio: 'inherit' },
+  );
+  writeStamp('browser-use', BROWSER_USE_STAMP);
+}
+
 function installAcpAdapters() {
   console.log('Installing ACP adapters...');
   execFileSync(
@@ -294,6 +313,12 @@ function run() {
     console.log('Dependencies up to date, skipping install.');
   } else {
     installPyDeps();
+  }
+
+  if (upToDate('browser-use', BROWSER_USE_STAMP, browserUsePython)) {
+    console.log('browser-use already installed, skipping install.');
+  } else {
+    installBrowserUse();
   }
 
   if (upToDate('rg', RG_STAMP, rgBin)) {

--- a/sandbox/docker/Dockerfile
+++ b/sandbox/docker/Dockerfile
@@ -52,22 +52,6 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | d
     apt-get install -y gh && \
     rm -rf /var/lib/apt/lists/*
 
-RUN set -eux; \
-    case "$(dpkg --print-architecture)" in \
-      amd64) \
-        curl -fsSL https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb -o /tmp/google-chrome.deb; \
-        apt-get update; \
-        apt-get install -y /tmp/google-chrome.deb fonts-liberation fonts-noto-color-emoji; \
-        google-chrome --version; \
-        rm /tmp/google-chrome.deb \
-        ;; \
-      arm64) \
-        : \
-        ;; \
-      *) exit 1 ;; \
-    esac; \
-    rm -rf /var/lib/apt/lists/*
-
 RUN curl -fsSL https://get.docker.com | sh && \
     mkdir -p /etc/docker && \
     echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
@@ -79,6 +63,7 @@ RUN useradd -m -s /bin/bash -u 1000 user && \
     chown -R user:user /home/user
 
 COPY --chmod=755 sandbox/docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY --chown=user:user --chmod=755 backend/app/browser_mcp_cloud.py /home/user/browser_mcp_cloud.py
 
 RUN set -eux; \
     version=20260818_01_RC01; \
@@ -149,17 +134,10 @@ RUN python3 -m pip install --user --upgrade pip && \
     python3 -m pip install --user \
     uv
 
-RUN set -eux; \
-    case "$(dpkg --print-architecture)" in \
-      amd64) \
-        uv tool install --python python3.12 'browser-use[cli]==0.13.8'; \
-        browser-use --version \
-        ;; \
-      arm64) \
-        : \
-        ;; \
-      *) exit 1 ;; \
-    esac
+RUN uv tool install --python python3.12 'browser-use[cli]==0.13.8' && \
+    command -v browser-use && \
+    /home/user/.local/share/uv/tools/browser-use/bin/python -c \
+      "from browser_mcp_cloud import CloudBrowserUseServer"
 
 RUN echo '#!/bin/bash\nexec echo $GITHUB_TOKEN' > /home/user/.git-askpass.sh && \
     chmod +x /home/user/.git-askpass.sh


### PR DESCRIPTION
## What

Replaces the local-Chromium browser automation (#941) with **browser-use Cloud remote browsers**, and extends browser tools beyond Docker sandboxes to host-mode and desktop.

- **Cloud routing wrapper** `backend/app/browser_mcp_cloud.py`: subclasses the browser-use 0.13.8 MCP server, forces `use_cloud=True` on the browser profile (the stock `--mcp` entry point cannot reach cloud via env vars), and stops the remote browser in a `finally` on exit — otherwise a cloud session bills until its idle timeout. Requires `BROWSER_USE_API_KEY`; fails fast without it. Direct tools need no LLM key.
- **Sandbox image slimmed ~864 MB (12.7%)**: Google Chrome + fonts removed; only the browser-use package remains, now installed on **all architectures** — the arm64 limitation from #941 is gone.
- **Host-mode + desktop support**: browser-use installed in an isolated venv in the backend image (`/app/browser-use`) and the desktop sidecar (`run_build.mjs`, stamped like other sidecar deps); `_build_mcp_server_configs` picks the right interpreter per provider.
- **Config simplified**: `AGENTROVE_BROWSER_MCP_ENABLED` removed — setting `BROWSER_USE_API_KEY` is the enable switch. `DOCKER_SHM_SIZE` and its HostConfig plumbing removed (only existed for local Chrome); the `_parse_byte_size` improvements stay.
- **One-shot sessions excluded**: the `browser` server is injected only when a real `chat_id` exists — title/commit-message generation (`_generate_text`, which forces the HOST provider with no chat) never spawns a browser MCP or touches cloud billing.

## Why cloud

Local headless Chromium in Docker is trivially blocked by hard targets (datacenter IP + headless fingerprint). browser-use Cloud's browser-infrastructure mode provides stealth Chromium in Firecracker micro-VMs with residential proxies and CAPTCHA handling, driven over CDP by the same OSS library — no local browser needed. Cost: $0.02/browser-hour + proxy data, billed to the configured API key.

## Validation

- `cd backend && uv run pytest tests/test_acp.py tests/test_sandbox.py` — 138 passed
- `cd backend && uv run ruff format --check . && uv run ruff check .` — clean
- Sandbox + backend Docker builds pass; image size 6.81 GB → 5.95 GB
- In-container stdio JSON-RPC against the wrapper: all 16 browser tools advertised with a dummy key and **no cloud contact** until a navigation; missing key exits 1 with a clear error
- Wrapper's `use_cloud` kwarg flow, `browser_session` attribute, and `kill()`-stops-cloud behavior verified against the installed 0.13.8 source
- Not verified: a live cloud browse (needs a real `bu_...` key) and the macOS desktop build (built on Linux; script syntax-checked)

## Deploy notes

- Set `BROWSER_USE_API_KEY=bu_...` to enable; unset = no browser tools anywhere.
- Recreate existing workspaces after the sandbox image updates (old containers keep the old image).
- If the backend/sandbox process is SIGKILLed mid-browse, the cloud session bills until the cloud-side timeout (60 min default). A follow-up could cap this by passing a short `timeout` via `cloud_browser_params`.