### PR TITLE
Render MCP tool result images (browser screenshots) as inline images with lightbox

### DIFF
--- a/frontend/src/components/chat/tools/claude/MCPTool.tsx
+++ b/frontend/src/components/chat/tools/claude/MCPTool.tsx
@@ -1,7 +1,9 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { Wrench } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import { formatResult, formatValue } from '@/utils/format';
+import { extractToolResultImages } from '@/utils/mcpToolImages';
+import { AttachmentViewer } from '@/components/ui/attachment-viewer/AttachmentViewer';
 import { ToolCard } from '../common/ToolCard/ToolCard';
 import toolText from '../common/toolText.module.scss';
 import toolIcon from './toolIcon.module.scss';
@@ -44,24 +46,35 @@ export const MCPTool = memo(function MCPTool({ tool }: MCPToolProps) {
     ([key]) => !(key === 'description' && description),
   );
   const hasInput = inputEntries.length > 0;
+  // Base64 image blocks (e.g. browser screenshots) render as real images; the
+  // remainder is what's left for the JSON/text output.
+  const { attachments: resultImages, remainder: textResult } = useMemo(
+    () => extractToolResultImages(tool.id, tool.result),
+    [tool.id, tool.result],
+  );
+  const hasImages = resultImages.length > 0;
   const hasResult = Boolean(
-    tool.result &&
-    (Array.isArray(tool.result)
-      ? tool.result.length > 0
-      : typeof tool.result === 'object'
-        ? Object.keys(tool.result as object).length > 0
+    textResult &&
+    (Array.isArray(textResult)
+      ? textResult.length > 0
+      : typeof textResult === 'object'
+        ? Object.keys(textResult as object).length > 0
         : true),
   );
-  const hasDetails = hasInput || hasResult;
+  const hasDetails = hasInput || hasResult || hasImages;
   const title = description ? `${formattedToolName}: ${description}` : formattedToolName;
 
   return (
     <ToolCard
+      // ToolCard reads defaultExpanded only at mount; remount when an image
+      // arrives mid-stream so screenshots open without a click.
+      key={hasImages ? 'image' : 'default'}
       icon={<Wrench className={toolIcon.icon} />}
       status={toolStatus}
       title={title}
       loadingContent="Processing..."
       error={errorMessage}
+      defaultExpanded={hasImages || undefined}
     >
       {hasDetails ? (
         <div className={styles.details}>
@@ -73,8 +86,9 @@ export const MCPTool = memo(function MCPTool({ tool }: MCPToolProps) {
                 </div>
               ))
             : null}
+          {hasImages ? <AttachmentViewer attachments={resultImages} /> : null}
           {hasResult ? (
-            <pre className={toolText['output-pre']}>{formatResult(tool.result)}</pre>
+            <pre className={toolText['output-pre']}>{formatResult(textResult)}</pre>
           ) : null}
         </div>
       ) : null}

--- a/frontend/src/utils/mcpToolImages.test.ts
+++ b/frontend/src/utils/mcpToolImages.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { extractToolResultImages } from './mcpToolImages';
+
+const PNG_DATA = 'iVBORw0KGgoAAAANSUhEUg==';
+
+describe('extractToolResultImages', () => {
+  it('returns the result untouched when there are no image blocks', () => {
+    const result = [{ type: 'text', text: 'hello' }];
+    const extracted = extractToolResultImages('t1', result);
+    expect(extracted.attachments).toHaveLength(0);
+    expect(extracted.remainder).toBe(result);
+  });
+
+  it('leaves plain string results untouched', () => {
+    const extracted = extractToolResultImages('t1', 'plain output');
+    expect(extracted.attachments).toHaveLength(0);
+    expect(extracted.remainder).toBe('plain output');
+  });
+
+  it('extracts Anthropic-style image blocks from a block array', () => {
+    const result = [
+      { type: 'text', text: '{"size_bytes": 477357}' },
+      { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_DATA } },
+    ];
+    const { attachments, remainder } = extractToolResultImages('tool-1', result);
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]).toMatchObject({
+      id: 'tool-1-image-0',
+      file_type: 'image',
+      file_url: `data:image/png;base64,${PNG_DATA}`,
+      filename: 'screenshot.png',
+    });
+    expect(remainder).toEqual([{ type: 'text', text: '{"size_bytes": 477357}' }]);
+  });
+
+  it('extracts MCP-standard image blocks with mimeType', () => {
+    const result = [{ type: 'image', data: PNG_DATA, mimeType: 'image/jpeg' }];
+    const { attachments, remainder } = extractToolResultImages('t1', result);
+
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0].file_url).toBe(`data:image/jpeg;base64,${PNG_DATA}`);
+    expect(attachments[0].filename).toBe('screenshot.jpg');
+    expect(remainder).toBeNull();
+  });
+
+  it('defaults the media type to image/png', () => {
+    const result = [{ type: 'image', data: PNG_DATA }];
+    const { attachments } = extractToolResultImages('t1', result);
+    expect(attachments[0].file_url).toBe(`data:image/png;base64,${PNG_DATA}`);
+  });
+
+  it('extracts image blocks nested in a content array', () => {
+    const result = {
+      content: [
+        { type: 'text', text: 'ok' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_DATA } },
+      ],
+      isError: false,
+    };
+    const { attachments, remainder } = extractToolResultImages('t1', result);
+
+    expect(attachments).toHaveLength(1);
+    expect(remainder).toEqual({ content: [{ type: 'text', text: 'ok' }], isError: false });
+  });
+
+  it('drops an emptied content array and nulls an emptied object', () => {
+    const { attachments, remainder } = extractToolResultImages('t1', {
+      content: [{ type: 'image', data: PNG_DATA }],
+    });
+    expect(attachments).toHaveLength(1);
+    expect(remainder).toBeNull();
+  });
+
+  it('handles a bare image block result', () => {
+    const { attachments, remainder } = extractToolResultImages('t1', {
+      type: 'image',
+      data: PNG_DATA,
+      mimeType: 'image/png',
+    });
+    expect(attachments).toHaveLength(1);
+    expect(remainder).toBeNull();
+  });
+
+  it('numbers filenames when multiple images are present', () => {
+    const result = [
+      { type: 'image', data: PNG_DATA },
+      { type: 'image', data: PNG_DATA },
+    ];
+    const { attachments } = extractToolResultImages('t1', result);
+    expect(attachments.map((a) => a.filename)).toEqual(['screenshot-1.png', 'screenshot-2.png']);
+    expect(attachments.map((a) => a.id)).toEqual(['t1-image-0', 't1-image-1']);
+  });
+
+  it('ignores image blocks with empty data', () => {
+    const result = [{ type: 'image', data: '' }];
+    const { attachments, remainder } = extractToolResultImages('t1', result);
+    expect(attachments).toHaveLength(0);
+    expect(remainder).toBe(result);
+  });
+});

--- a/frontend/src/utils/mcpToolImages.ts
+++ b/frontend/src/utils/mcpToolImages.ts
@@ -1,0 +1,107 @@
+import type { MessageAttachment } from '@/types/chat.types';
+
+// MCP tool results can carry base64 image content blocks (e.g. browser
+// screenshots) in two shapes: Anthropic-style
+// { type: 'image', source: { type: 'base64', media_type, data } } and
+// MCP-standard { type: 'image', data, mimeType }. Extract them so tool cards
+// can render real images instead of dumping base64 into the JSON output.
+
+interface ImageBlock {
+  mediaType: string;
+  data: string;
+}
+
+const IMAGE_EXTENSIONS: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+const asImageBlock = (block: unknown): ImageBlock | null => {
+  if (typeof block !== 'object' || block === null) return null;
+  const candidate = block as Record<string, unknown>;
+  if (candidate.type !== 'image') return null;
+
+  const source = candidate.source;
+  if (typeof source === 'object' && source !== null) {
+    const { media_type: mediaType, data } = source as Record<string, unknown>;
+    if (typeof data === 'string' && data) {
+      return {
+        mediaType: typeof mediaType === 'string' && mediaType ? mediaType : 'image/png',
+        data,
+      };
+    }
+  }
+
+  if (typeof candidate.data === 'string' && candidate.data) {
+    const mimeType = candidate.mimeType;
+    return {
+      mediaType: typeof mimeType === 'string' && mimeType ? mimeType : 'image/png',
+      data: candidate.data,
+    };
+  }
+
+  return null;
+};
+
+export interface ExtractedToolImages {
+  attachments: MessageAttachment[];
+  // The result with image blocks removed, so the text output renders without base64 noise.
+  remainder: unknown;
+}
+
+export const extractToolResultImages = (toolId: string, result: unknown): ExtractedToolImages => {
+  const images: ImageBlock[] = [];
+
+  const filterBlocks = (blocks: unknown[]): unknown[] =>
+    blocks.filter((block) => {
+      const image = asImageBlock(block);
+      if (image) {
+        images.push(image);
+        return false;
+      }
+      return true;
+    });
+
+  let remainder: unknown = result;
+
+  if (Array.isArray(result)) {
+    const rest = filterBlocks(result);
+    if (images.length > 0) {
+      remainder = rest.length > 0 ? rest : null;
+    }
+  } else if (asImageBlock(result)) {
+    images.push(asImageBlock(result)!);
+    remainder = null;
+  } else if (typeof result === 'object' && result !== null) {
+    const record = result as Record<string, unknown>;
+    if (Array.isArray(record.content)) {
+      const rest = filterBlocks(record.content);
+      if (images.length > 0) {
+        const next: Record<string, unknown> = { ...record };
+        if (rest.length > 0) {
+          next.content = rest;
+        } else {
+          delete next.content;
+        }
+        remainder = Object.keys(next).length > 0 ? next : null;
+      }
+    }
+  }
+
+  const attachments = images.map((image, index): MessageAttachment => {
+    const extension = IMAGE_EXTENSIONS[image.mediaType] ?? 'png';
+    return {
+      id: `${toolId}-image-${index}`,
+      message_id: '',
+      file_url: `data:${image.mediaType};base64,${image.data}`,
+      file_type: 'image',
+      filename:
+        images.length > 1 ? `screenshot-${index + 1}.${extension}` : `screenshot.${extension}`,
+      created_at: '',
+    };
+  });
+
+  return { attachments, remainder };
+};


### PR DESCRIPTION
## What

MCP tool results carrying base64 image content blocks — e.g. `browser_screenshot` from the browser MCP (#942) — previously rendered as raw JSON with the base64 payload dumped into the tool card's `<pre>`. They now render as real inline images with click-to-expand.

- New `extractToolResultImages` util (`frontend/src/utils/mcpToolImages.ts`): pulls image blocks out of a tool result, handling both the Anthropic shape (`{type:"image", source:{type:"base64", media_type, data}}`) and the MCP-standard shape (`{type:"image", data, mimeType}`), whether the result is a block array, a `{content: [...]}` object, or a bare image block. Returns synthesized image attachments plus the remainder (with base64 stripped) for the text output. Preserves reference identity when no images are present.
- `MCPTool.tsx` renders extracted images through the existing `AttachmentViewer`, which provides thumbnails, the `ImagePreviewModal` lightbox (click-to-expand full size, keyboard nav), and download — same UX as message attachments. The card auto-expands when a screenshot arrives (same remount pattern as the codex image-generation card). Remaining text/JSON renders as before, minus the base64 noise.

## Coverage

`MCPTool` is the fallback renderer for all unmatched tool names across every agent lane (Claude, Grok, Antigravity explicitly, plus the generic fallback), and codex's `OtherTool` already falls through to `MCPTool` for MCP-shaped payloads — so the single change covers browser screenshots from any CLI.

## Validation

- 10 new unit tests for the extractor (both shapes, nesting, defaults, multi-image, empty-data guard)
- Full frontend suite: 76 files / 781 tests pass
- `tsc --noEmit` and eslint clean on touched files