### PR TITLE
Fix mypy no-untyped-def in browser_mcp_cloud wrapper

### DIFF
--- a/backend/app/browser_mcp_cloud.py
+++ b/backend/app/browser_mcp_cloud.py
@@ -3,14 +3,15 @@
 import asyncio
 import os
 import sys
+from typing import Any
 
 from browser_use.mcp.server import BrowserUseServer
 
 
 class CloudBrowserUseServer(BrowserUseServer):
     async def _init_browser_session(
-        self, allowed_domains: list[str] | None = None, **kwargs
-    ):
+        self, allowed_domains: list[str] | None = None, **kwargs: Any
+    ) -> None:
         # The upstream MCP server otherwise always creates a local browser profile.
         kwargs["use_cloud"] = True
         await super()._init_browser_session(allowed_domains=allowed_domains, **kwargs)


### PR DESCRIPTION
Annotates the `_init_browser_session` override in `backend/app/browser_mcp_cloud.py` (`**kwargs: Any`, `-> None`), fixing the two `no-untyped-def` mypy errors. Matches the upstream browser-use 0.13.8 method contract (returns None). Ruff format/check clean; no behavior change.