### PR TITLE
deptry: ignore DEP001 for browser_use (isolated venv, not a backend dep)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -104,6 +104,9 @@ exclude = [
 DEP001 = [
     "pytest",
     "pytest_asyncio",
+    # app/browser_mcp_cloud.py runs under the isolated /app/browser-use venv's
+    # interpreter (see backend/Dockerfile), never imported by the backend app.
+    "browser_use",
 ]
 DEP002 = [
     "aiosqlite",


### PR DESCRIPTION
Adds `browser_use` to deptry's DEP001 per-rule ignores. `app/browser_mcp_cloud.py` imports it, but the module is intentionally absent from backend dependency definitions: the wrapper is executed by the isolated `/app/browser-use` venv's interpreter (created in `backend/Dockerfile` / desktop sidecar), never imported by the backend app — same pattern as the existing `mcp` ignore for the bundled mcp-server. Verified `deptry .` no longer reports `browser_use`.