### PR TITLE
Screenshot cards: metadata caption + large inline preview

### DIFF
--- a/frontend/src/components/chat/tools/claude/MCPTool.module.scss
+++ b/frontend/src/components/chat/tools/claude/MCPTool.module.scss
@@ -17,3 +17,8 @@
   @include type.type-mono-meta;
   color: var(--theme-text-tertiary);
 }
+
+.caption {
+  @include type.type-meta;
+  color: var(--theme-text-quaternary);
+}

--- a/frontend/src/components/chat/tools/claude/MCPTool.tsx
+++ b/frontend/src/components/chat/tools/claude/MCPTool.tsx
@@ -3,8 +3,8 @@ import { Wrench } from 'lucide-react';
 import type { ToolAggregate } from '@/types/tools.types';
 import { formatResult, formatValue } from '@/utils/format';
 import { extractToolResultImages } from '@/utils/mcpToolImages';
-import { AttachmentViewer } from '@/components/ui/attachment-viewer/AttachmentViewer';
 import { ToolCard } from '../common/ToolCard/ToolCard';
+import { ToolResultImages } from '../common/ToolResultImages/ToolResultImages';
 import toolText from '../common/toolText.module.scss';
 import toolIcon from './toolIcon.module.scss';
 import styles from './MCPTool.module.scss';
@@ -46,12 +46,11 @@ export const MCPTool = memo(function MCPTool({ tool }: MCPToolProps) {
     ([key]) => !(key === 'description' && description),
   );
   const hasInput = inputEntries.length > 0;
-  // Base64 image blocks (e.g. browser screenshots) render as real images; the
-  // remainder is what's left for the JSON/text output.
-  const { attachments: resultImages, remainder: textResult } = useMemo(
-    () => extractToolResultImages(tool.id, tool.result),
-    [tool.id, tool.result],
-  );
+  const {
+    attachments: resultImages,
+    caption,
+    remainder: textResult,
+  } = useMemo(() => extractToolResultImages(tool.id, tool.result), [tool.id, tool.result]);
   const hasImages = resultImages.length > 0;
   const hasResult = Boolean(
     textResult &&
@@ -86,7 +85,8 @@ export const MCPTool = memo(function MCPTool({ tool }: MCPToolProps) {
                 </div>
               ))
             : null}
-          {hasImages ? <AttachmentViewer attachments={resultImages} /> : null}
+          {hasImages ? <ToolResultImages attachments={resultImages} /> : null}
+          {caption ? <p className={styles.caption}>{caption}</p> : null}
           {hasResult ? (
             <pre className={toolText['output-pre']}>{formatResult(textResult)}</pre>
           ) : null}

--- a/frontend/src/components/chat/tools/common/ToolResultImages/ToolResultImages.module.scss
+++ b/frontend/src/components/chat/tools/common/ToolResultImages/ToolResultImages.module.scss
@@ -1,0 +1,27 @@
+@use '@/styles/globals/controls' as controls;
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1-5);
+  width: 100%;
+}
+
+.button {
+  @include controls.focus-ring;
+  width: 100%;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-md);
+  background: transparent;
+  cursor: zoom-in;
+}
+
+.image {
+  display: block;
+  width: 100%;
+  max-height: 360px;
+  border-radius: var(--radius-md);
+  object-fit: contain;
+}

--- a/frontend/src/components/chat/tools/common/ToolResultImages/ToolResultImages.tsx
+++ b/frontend/src/components/chat/tools/common/ToolResultImages/ToolResultImages.tsx
@@ -1,0 +1,60 @@
+import { memo, useMemo, useState } from 'react';
+import type { MessageAttachment } from '@/types/chat.types';
+import { ImagePreviewModal } from '@/components/ui/ImagePreviewModal/ImagePreviewModal';
+import styles from './ToolResultImages.module.scss';
+
+interface ToolResultImagesProps {
+  attachments: MessageAttachment[];
+}
+
+export const ToolResultImages = memo(function ToolResultImages({
+  attachments,
+}: ToolResultImagesProps) {
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+  const imageStates = useMemo(
+    () =>
+      Object.fromEntries(
+        attachments.map((attachment) => [
+          attachment.id,
+          { isLoading: false, error: false, imageSrc: attachment.file_url },
+        ]),
+      ),
+    [attachments],
+  );
+
+  const handleDownload = (url: string, filename: string) => {
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  return (
+    <>
+      <div className={styles.list}>
+        {attachments.map((attachment, index) => (
+          <button
+            key={attachment.id}
+            type="button"
+            className={styles.button}
+            onClick={() => setPreviewIndex(index)}
+            aria-label={`Preview ${attachment.filename}`}
+          >
+            <img src={attachment.file_url} alt={attachment.filename} className={styles.image} />
+          </button>
+        ))}
+      </div>
+      <ImagePreviewModal
+        isOpen={previewIndex !== null}
+        onClose={() => setPreviewIndex(null)}
+        attachments={attachments}
+        imageStates={imageStates}
+        currentIndex={previewIndex ?? 0}
+        onIndexChange={setPreviewIndex}
+        onDownload={handleDownload}
+      />
+    </>
+  );
+});

--- a/frontend/src/utils/mcpToolImages.test.ts
+++ b/frontend/src/utils/mcpToolImages.test.ts
@@ -22,7 +22,7 @@ describe('extractToolResultImages', () => {
       { type: 'text', text: '{"size_bytes": 477357}' },
       { type: 'image', source: { type: 'base64', media_type: 'image/png', data: PNG_DATA } },
     ];
-    const { attachments, remainder } = extractToolResultImages('tool-1', result);
+    const { attachments, caption, remainder } = extractToolResultImages('tool-1', result);
 
     expect(attachments).toHaveLength(1);
     expect(attachments[0]).toMatchObject({
@@ -31,7 +31,48 @@ describe('extractToolResultImages', () => {
       file_url: `data:image/png;base64,${PNG_DATA}`,
       filename: 'screenshot.png',
     });
-    expect(remainder).toEqual([{ type: 'text', text: '{"size_bytes": 477357}' }]);
+    expect(caption).toBe('466.2 KB');
+    expect(remainder).toBeNull();
+  });
+
+  it('turns screenshot size and viewport metadata into a caption', () => {
+    const result = [
+      {
+        type: 'text',
+        text: '{"size_bytes":322501,"viewport":{"width":1521,"height":643}}',
+      },
+      { type: 'image', data: PNG_DATA },
+    ];
+
+    expect(extractToolResultImages('t1', result)).toMatchObject({
+      caption: '1521 × 643 · 314.9 KB',
+      remainder: null,
+    });
+  });
+
+  it.each([
+    ['viewport-only', '{"viewport":{"width":800,"height":600}}', '800 × 600'],
+    ['size-only', '{"size_bytes":1024}', '1.0 KB'],
+  ])('formats %s screenshot metadata', (_name, text, caption) => {
+    const result = [
+      { type: 'text', text },
+      { type: 'image', data: PNG_DATA },
+    ];
+
+    expect(extractToolResultImages('t1', result)).toMatchObject({ caption, remainder: null });
+  });
+
+  it.each([
+    ['non-metadata text', 'Screenshot complete'],
+    ['metadata with extra keys', '{"size_bytes":1024,"url":"https://example.com"}'],
+  ])('preserves %s', (_name, text) => {
+    const textBlock = { type: 'text', text };
+    const result = [textBlock, { type: 'image', data: PNG_DATA }];
+
+    expect(extractToolResultImages('t1', result)).toMatchObject({
+      caption: null,
+      remainder: [textBlock],
+    });
   });
 
   it('extracts MCP-standard image blocks with mimeType', () => {

--- a/frontend/src/utils/mcpToolImages.ts
+++ b/frontend/src/utils/mcpToolImages.ts
@@ -1,4 +1,5 @@
 import type { MessageAttachment } from '@/types/chat.types';
+import { formatBytes } from '@/utils/format';
 
 // MCP tool results can carry base64 image content blocks (e.g. browser
 // screenshots) in two shapes: Anthropic-style
@@ -47,9 +48,90 @@ const asImageBlock = (block: unknown): ImageBlock | null => {
 
 export interface ExtractedToolImages {
   attachments: MessageAttachment[];
-  // The result with image blocks removed, so the text output renders without base64 noise.
+  caption: string | null;
   remainder: unknown;
 }
+
+interface ScreenshotMetadata {
+  size_bytes?: number;
+  viewport?: {
+    width: number;
+    height: number;
+  };
+}
+
+const asScreenshotMetadata = (block: unknown): ScreenshotMetadata | null => {
+  if (typeof block !== 'object' || block === null) return null;
+  const textBlock = block as Record<string, unknown>;
+  if (textBlock.type !== 'text' || typeof textBlock.text !== 'string') return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(textBlock.text);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return null;
+  const metadata = parsed as Record<string, unknown>;
+  const keys = Object.keys(metadata);
+  if (keys.length === 0 || keys.some((key) => key !== 'size_bytes' && key !== 'viewport')) {
+    return null;
+  }
+
+  let sizeBytes: number | undefined;
+  if ('size_bytes' in metadata) {
+    if (
+      typeof metadata.size_bytes !== 'number' ||
+      !Number.isFinite(metadata.size_bytes) ||
+      metadata.size_bytes < 0
+    ) {
+      return null;
+    }
+    sizeBytes = metadata.size_bytes;
+  }
+
+  let parsedViewport: ScreenshotMetadata['viewport'];
+  if ('viewport' in metadata) {
+    if (
+      typeof metadata.viewport !== 'object' ||
+      metadata.viewport === null ||
+      Array.isArray(metadata.viewport)
+    ) {
+      return null;
+    }
+    const viewport = metadata.viewport as Record<string, unknown>;
+    if (
+      Object.keys(viewport).length !== 2 ||
+      !('width' in viewport) ||
+      !('height' in viewport) ||
+      typeof viewport.width !== 'number' ||
+      !Number.isFinite(viewport.width) ||
+      typeof viewport.height !== 'number' ||
+      !Number.isFinite(viewport.height)
+    ) {
+      return null;
+    }
+    parsedViewport = { width: viewport.width, height: viewport.height };
+  }
+
+  return { size_bytes: sizeBytes, viewport: parsedViewport };
+};
+
+const extractScreenshotCaption = (remainder: unknown): string | null => {
+  if (!Array.isArray(remainder) || remainder.length === 0) return null;
+  const metadata = remainder.map(asScreenshotMetadata);
+  if (metadata.some((item) => item === null)) return null;
+
+  const parts: string[] = [];
+  for (const item of metadata) {
+    if (item?.viewport) parts.push(`${item.viewport.width} × ${item.viewport.height}`);
+  }
+  for (const item of metadata) {
+    if (item?.size_bytes !== undefined) parts.push(formatBytes(item.size_bytes));
+  }
+  return parts.join(' · ');
+};
 
 export const extractToolResultImages = (toolId: string, result: unknown): ExtractedToolImages => {
   const images: ImageBlock[] = [];
@@ -65,11 +147,13 @@ export const extractToolResultImages = (toolId: string, result: unknown): Extrac
     });
 
   let remainder: unknown = result;
+  let caption: string | null = null;
 
   if (Array.isArray(result)) {
     const rest = filterBlocks(result);
     if (images.length > 0) {
-      remainder = rest.length > 0 ? rest : null;
+      caption = extractScreenshotCaption(rest);
+      remainder = caption !== null || rest.length === 0 ? null : rest;
     }
   } else if (asImageBlock(result)) {
     images.push(asImageBlock(result)!);
@@ -79,8 +163,9 @@ export const extractToolResultImages = (toolId: string, result: unknown): Extrac
     if (Array.isArray(record.content)) {
       const rest = filterBlocks(record.content);
       if (images.length > 0) {
+        caption = extractScreenshotCaption(rest);
         const next: Record<string, unknown> = { ...record };
-        if (rest.length > 0) {
+        if (rest.length > 0 && !caption) {
           next.content = rest;
         } else {
           delete next.content;
@@ -103,5 +188,5 @@ export const extractToolResultImages = (toolId: string, result: unknown): Extrac
     };
   });
 
-  return { attachments, remainder };
+  return { attachments, caption, remainder };
 };


### PR DESCRIPTION
## What

Two UX changes to MCP screenshot tool cards (follow-up to #943), per review of the live rendering:

1. **Metadata caption instead of raw JSON.** When the only remaining output after image extraction is the screenshot metadata block (`size_bytes`/`viewport`), it renders as a muted one-line caption under the image — `1521 × 643 · 314.9 KB` — and the JSON disappears. Parsing is strict: any other text, non-text blocks, extra JSON keys, or malformed values fall back to the existing raw output, so generic MCP tools never lose real content.
2. **Large inline preview.** New `ToolResultImages` component renders screenshots at full card width (capped 360px, object-fit contain) instead of the ~90px attachment thumbnail — readable without interaction. Click still opens the existing `ImagePreviewModal` lightbox (keyboard nav + download). Multiple images stack. Message-attachment rendering elsewhere is untouched.

## Validation

- Frontend suite: 76 files / 786 tests pass (5 new caption/fallback cases)
- `tsc --noEmit`, eslint (touched files), `npm run format:check` all clean