### PR TITLE
fix: point claude-agent-acp at Claude Code 2.1.257

### DIFF
--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -302,9 +302,6 @@ class ClaudeAgentAdapter(AgentAdapter):
         reasoning_effort: str | None = None,
         permission_mode: str | None = None,
     ) -> LaunchConfig:
-        # claude-agent-acp 0.71.0 pins Agent SDK 0.3.238 (Claude Code 2.1.238).
-        # Fable 5.1 requires 2.1.251+, so use the separately installed `claude`
-        # CLI instead of the SDK's bundled binary.
         return LaunchConfig(
             binary="claude-agent-acp",
             env={"CLAUDE_CODE_EXECUTABLE": "claude"},

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -302,8 +302,13 @@ class ClaudeAgentAdapter(AgentAdapter):
         reasoning_effort: str | None = None,
         permission_mode: str | None = None,
     ) -> LaunchConfig:
-        # Config via env + session meta only (no CLI args).
-        return LaunchConfig(binary="claude-agent-acp")
+        # claude-agent-acp 0.71.0 pins Agent SDK 0.3.238 (Claude Code 2.1.238).
+        # Fable 5.1 requires 2.1.251+, so use the separately installed `claude`
+        # CLI instead of the SDK's bundled binary.
+        return LaunchConfig(
+            binary="claude-agent-acp",
+            env={"CLAUDE_CODE_EXECUTABLE": "claude"},
+        )
 
     def build_session_config(
         self,

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -147,6 +147,16 @@ def test_grok_launch_args_apply_always_approve_flag(
     assert launch.cli_args == expected_args
 
 
+def test_claude_launch_uses_installed_claude_cli() -> None:
+    launch = ClaudeAgentAdapter().build_launch_config(
+        system_prompt=None,
+        system_prompt_is_full_replace=False,
+    )
+
+    assert launch.binary == "claude-agent-acp"
+    assert launch.env == {"CLAUDE_CODE_EXECUTABLE": "claude"}
+
+
 @pytest.mark.parametrize(
     "model_id,thinking_mode,expected_effort",
     [

--- a/desktop/run_build.mjs
+++ b/desktop/run_build.mjs
@@ -23,6 +23,7 @@ const NODE_VERSION = '22.12.0';
 const RELEASE_TAG = '20260211';
 const RIPGREP_VERSION = '14.1.1';
 const CLAUDE_AGENT_ACP_VERSION = '0.71.0';
+const CLAUDE_CODE_VERSION = '2.1.257';
 const CODEX_ACP_VERSION = '1.6.0';
 const BROWSER_USE_VERSION = '0.13.8';
 const GET_PIP_URL = 'https://bootstrap.pypa.io/get-pip.py';
@@ -51,7 +52,7 @@ const codexAcpBin = join(sidecarBinDir, 'codex-acp');
 const PYTHON_STAMP = `${PYTHON_VERSION}+${RELEASE_TAG}-${arch}-${platform}`;
 const NODE_STAMP = `${NODE_VERSION}-${arch}-${platform}`;
 const RG_STAMP = `${RIPGREP_VERSION}-${arch}-${platform}`;
-const ACP_STAMP = `${CLAUDE_AGENT_ACP_VERSION}-${CODEX_ACP_VERSION}-${NODE_STAMP}`;
+const ACP_STAMP = `${CLAUDE_AGENT_ACP_VERSION}-${CLAUDE_CODE_VERSION}-${CODEX_ACP_VERSION}-${NODE_STAMP}`;
 const BROWSER_USE_STAMP = `${BROWSER_USE_VERSION}-${PYTHON_STAMP}`;
 
 function stampPath(name) {
@@ -224,6 +225,7 @@ function installAcpAdapters() {
       'install', '--prefix', sidecarDir,
       '--omit=dev', '--no-audit', '--no-fund', '--package-lock=false',
       `@agentclientprotocol/claude-agent-acp@${CLAUDE_AGENT_ACP_VERSION}`,
+      `@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}`,
       `@agentclientprotocol/codex-acp@${CODEX_ACP_VERSION}`,
     ],
     { stdio: 'inherit' },
@@ -243,9 +245,22 @@ function writeAcpLauncher(name, packageEntry) {
   chmodSync(launcher, 0o755);
 }
 
+function writeClaudeCliLauncher() {
+  const launcher = join(sidecarBinDir, 'claude');
+  mkdirSync(sidecarBinDir, { recursive: true });
+  writeFileSync(
+    launcher,
+    '#!/bin/bash\n' +
+      'SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"\n' +
+      'exec "$SCRIPT_DIR/../node_modules/.bin/claude" "$@"\n',
+  );
+  chmodSync(launcher, 0o755);
+}
+
 function writeAcpLaunchers() {
   writeAcpLauncher('claude-agent-acp', '@agentclientprotocol/claude-agent-acp/dist/index.js');
   writeAcpLauncher('codex-acp', '@agentclientprotocol/codex-acp/dist/index.js');
+  writeClaudeCliLauncher();
 }
 
 function copySource() {


### PR DESCRIPTION
## Summary
- `claude-agent-acp` 0.71.0 pins `@anthropic-ai/claude-agent-sdk` 0.3.238, whose bundled CLI reports as Claude Code 2.1.238
- Fable 5.1 requires Claude Code 2.1.251+, which is why sessions fail with `Claude Code 2.1.238 does not support this model`
- Set `CLAUDE_CODE_EXECUTABLE=claude` so ACP uses the separately installed 2.1.257 CLI instead of the SDK binary
- Bundle `@anthropic-ai/claude-code@2.1.257` in the desktop sidecar so host/desktop sessions resolve the same CLI

## Test plan
- [x] `pytest tests/test_acp.py::test_claude_launch_uses_installed_claude_cli tests/test_acp.py::test_claude_session_config_gates_effort_by_model` passes
- [ ] Rebuild sandbox/backend images (or desktop sidecar) so `claude --version` is 2.1.257
- [ ] Start a Claude turn on Fable 5.1 and confirm it no longer errors about 2.1.238