### PR TITLE
feat: add Gemini 3.8 Flash

### DIFF
--- a/backend/app/constants.py
+++ b/backend/app/constants.py
@@ -180,6 +180,9 @@ MODELS: dict[str, ModelInfo] = {
     "copilot:mai-code-1-flash-picker": ModelInfo(
         "MAI Code 1 Flash", AgentKind.COPILOT, 128_000
     ),
+    "copilot:gemini-3.8-flash": ModelInfo(
+        "Gemini 3.8 Flash", AgentKind.COPILOT, 1_000_000
+    ),
     "copilot:gemini-3.6-flash": ModelInfo(
         "Gemini 3.6 Flash", AgentKind.COPILOT, 1_000_000
     ),
@@ -240,6 +243,9 @@ MODELS: dict[str, ModelInfo] = {
     "cursor:kimi-k2.5": ModelInfo("Kimi K2.5", AgentKind.CURSOR, 262_000),
     "grok:grok-4.6": ModelInfo("Grok 4.6", AgentKind.GROK, 500_000),
     "grok:grok-4.5": ModelInfo("Grok 4.5", AgentKind.GROK, 500_000),
+    "antigravity:gemini-3.8-flash": ModelInfo(
+        "Gemini 3.8 Flash", AgentKind.ANTIGRAVITY, 1_000_000
+    ),
     "antigravity:gemini-3.7-flash": ModelInfo(
         "Gemini 3.7 Flash", AgentKind.ANTIGRAVITY, 1_000_000
     ),
@@ -314,6 +320,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
     "opencode:opencode/gemini-3.6-flash": ModelInfo(
         "Gemini 3.6 Flash (OpenCode)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:opencode/gemini-3.8-flash": ModelInfo(
+        "Gemini 3.8 Flash (OpenCode)", AgentKind.OPENCODE, 1_048_576
     ),
     "opencode:opencode/glm-5": ModelInfo(
         "GLM-5 (OpenCode)", AgentKind.OPENCODE, 204_800
@@ -917,6 +926,9 @@ MODELS: dict[str, ModelInfo] = {
     "opencode:github-copilot/gemini-3.6-flash": ModelInfo(
         "Gemini 3.6 Flash (Github Copilot)", AgentKind.OPENCODE, 1_000_000
     ),
+    "opencode:github-copilot/gemini-3.8-flash": ModelInfo(
+        "Gemini 3.8 Flash (Github Copilot)", AgentKind.OPENCODE, 1_000_000
+    ),
     "opencode:github-copilot/gpt-4.1": ModelInfo(
         "GPT-4.1 (Github Copilot)", AgentKind.OPENCODE, 128_000
     ),
@@ -1040,6 +1052,9 @@ MODELS: dict[str, ModelInfo] = {
     "opencode:google/gemini-3.6-flash": ModelInfo(
         "Gemini 3.6 Flash (Google)", AgentKind.OPENCODE, 1_048_576
     ),
+    "opencode:google/gemini-3.8-flash": ModelInfo(
+        "Gemini 3.8 Flash (Google)", AgentKind.OPENCODE, 1_048_576
+    ),
     "opencode:google/gemini-embedding-001": ModelInfo(
         "Gemini Embedding 001 (Google)", AgentKind.OPENCODE, 2_048
     ),
@@ -1152,6 +1167,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
     "opencode:google-vertex/gemini-3.6-flash": ModelInfo(
         "Gemini 3.6 Flash (Google Vertex)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:google-vertex/gemini-3.8-flash": ModelInfo(
+        "Gemini 3.8 Flash (Google Vertex)", AgentKind.OPENCODE, 1_048_576
     ),
     "opencode:google-vertex/gemini-embedding-001": ModelInfo(
         "Gemini Embedding 001 (Google Vertex)", AgentKind.OPENCODE, 2_048
@@ -1444,6 +1462,9 @@ MODELS: dict[str, ModelInfo] = {
     ),
     "opencode:openrouter/google/gemini-3.6-flash": ModelInfo(
         "Gemini 3.6 Flash (Openrouter)", AgentKind.OPENCODE, 1_048_576
+    ),
+    "opencode:openrouter/google/gemini-3.8-flash": ModelInfo(
+        "Gemini 3.8 Flash (Openrouter)", AgentKind.OPENCODE, 1_048_576
     ),
     "opencode:openrouter/google/gemma-2-27b-it": ModelInfo(
         "Gemma 2 27B (Openrouter)", AgentKind.OPENCODE, 8_192

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -98,6 +98,7 @@ COPILOT_REASONING_MODEL_IDS = frozenset(
     {
         "copilot:gpt-5-mini",
         "copilot:mai-code-1-flash-picker",
+        "copilot:gemini-3.8-flash",
         "copilot:gemini-3.6-flash",
         "copilot:gemini-3.5-flash",
         "copilot:gemini-3.1-pro-preview",

--- a/backend/tests/test_acp.py
+++ b/backend/tests/test_acp.py
@@ -84,6 +84,12 @@ def test_antigravity_adapter_configuration() -> None:
 
     assert launch.binary == "agy-acp-server"
     assert launch.cli_args == []
+    assert adapter.map_model_id("antigravity:gemini-3.8-flash", None) == (
+        "gemini-3.8-flash-high"
+    )
+    assert adapter.map_model_id("antigravity:gemini-3.8-flash", "low") == (
+        "gemini-3.8-flash-low"
+    )
     assert adapter.map_model_id("antigravity:gemini-3.7-flash", None) == (
         "gemini-3.7-flash-high"
     )

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -77,7 +77,17 @@ async def test_list_models_returns_registered_models(
         "high",
         "xhigh",
     ]
+    assert by_id["antigravity:gemini-3.8-flash"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+    ]
     assert by_id["antigravity:gemini-3.7-flash"]["thinking_modes"] == [
+        "low",
+        "medium",
+        "high",
+    ]
+    assert by_id["copilot:gemini-3.8-flash"]["thinking_modes"] == [
         "low",
         "medium",
         "high",

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -84,6 +84,7 @@ const COPILOT_THINKING_MODES: ThinkingModeOption[] = [
 const COPILOT_REASONING_MODEL_IDS = new Set([
   'copilot:gpt-5-mini',
   'copilot:mai-code-1-flash-picker',
+  'copilot:gemini-3.8-flash',
   'copilot:gemini-3.6-flash',
   'copilot:gemini-3.5-flash',
   'copilot:gemini-3.1-pro-preview',

--- a/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
+++ b/frontend/src/components/chat/thinking-mode-selector/thinkingModes.ts
@@ -20,11 +20,7 @@ const CLAUDE_XHIGH_THINKING_MODES: ThinkingModeOption[] = [
   { value: 'xhigh', label: 'XHigh' },
   { value: 'max', label: 'Max' },
 ];
-const CLAUDE_XHIGH_MODEL_IDS = new Set([
-  'claude-fable-5-1',
-  'claude-fable-5',
-  'claude-opus-5',
-]);
+const CLAUDE_XHIGH_MODEL_IDS = new Set(['claude-fable-5-1', 'claude-fable-5', 'claude-opus-5']);
 // claude-agent-acp only exposes the effort dial for models that report
 // supportsEffort — Haiku doesn't, so hide the selector. Mirrors
 // CLAUDE_NO_EFFORT_MODEL_IDS in backend app/services/acp/adapters.py.


### PR DESCRIPTION
## Summary
- Register Google's Gemini 3.8 Flash (`gemini-3.8-flash`, released Sep 2) in the model catalog for Antigravity, GitHub Copilot, and OpenCode (Zen, Google, Vertex, OpenRouter, GitHub Copilot).
- Enable Copilot's low/medium/high thinking dial for the new model, matching 3.5/3.6 Flash.
- Cover Antigravity ACP model-id mapping and catalog thinking modes in tests.

Cursor still only catalogs generic `gemini-3-flash`, so no Cursor-specific ID was added.

## Test plan
- [x] `backend/.venv/bin/pytest tests/test_models.py tests/test_acp.py::test_antigravity_adapter_configuration`
- [ ] Pick Gemini 3.8 Flash in the model picker for Antigravity, Copilot, and OpenCode
- [ ] Confirm the thinking-mode selector shows Low/Medium/High for Antigravity and Copilot