### PR TITLE
refactor: collapse ACP adapters into a data-driven base class

### DIFF
--- a/backend/app/api/endpoints/ai_model.py
+++ b/backend/app/api/endpoints/ai_model.py
@@ -4,11 +4,7 @@ from app.core.security import get_current_user
 from app.models.db_models.user import User
 from app.models.schemas.ai_model import AIModelResponse
 from app.constants import MODELS
-from app.services.acp.adapters import (
-    THINKING_MODE_ORDER,
-    AgentKind,
-    valid_thinking_modes,
-)
+from app.services.acp.adapters import AGENT_ADAPTERS, THINKING_MODE_ORDER, AgentKind
 
 router = APIRouter()
 
@@ -35,7 +31,7 @@ async def list_models(
             agent_kind=info.agent_kind,
             context_window=info.context_window,
             thinking_modes=sorted(
-                valid_thinking_modes(info.agent_kind, mid),
+                AGENT_ADAPTERS[info.agent_kind].valid_thinking_modes(mid),
                 key=THINKING_MODE_ORDER.index,
             ),
         )

--- a/backend/app/services/acp/adapters.py
+++ b/backend/app/services/acp/adapters.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from abc import ABC, abstractmethod
 from enum import Enum
 from dataclasses import dataclass, field
 from typing import Any
@@ -37,100 +36,6 @@ NATIVE_FILE_TYPES: dict[AgentKind, frozenset[str]] = {
     AgentKind.OPENCODE: frozenset({"image"}),
 }
 
-
-# UI permission mode → codex-acp session mode (each bundles approval + sandbox policy).
-CODEX_SESSION_MODES: dict[str, str] = {
-    "auto": "agent",
-    "read-only": "read-only",
-    "full-access": "agent-full-access",
-}
-COPILOT_SESSION_MODES = frozenset({"agent", "plan", "autopilot"})
-COPILOT_SESSION_MODE_BASE_URL = "https://agentclientprotocol.com/protocol/session-modes"
-COPILOT_SESSION_MODE_IDS: dict[str, str] = {
-    mode: f"{COPILOT_SESSION_MODE_BASE_URL}#{mode}" for mode in COPILOT_SESSION_MODES
-}
-
-CLAUDE_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "max"})
-CLAUDE_XHIGH_VALID_THINKING_MODES = CLAUDE_VALID_THINKING_MODES | {"xhigh"}
-CLAUDE_XHIGH_MODEL_IDS = frozenset(
-    {"claude-fable-5-1", "claude-fable-5", "claude-opus-5"}
-)
-# claude-agent-acp only advertises the "effort" config option for models that
-# report supportsEffort — Haiku doesn't, so set_config_option("effort") fails
-# with "Unknown config option: effort". Empty set = no effort dial for these.
-CLAUDE_NO_EFFORT_MODEL_IDS = frozenset({"haiku"})
-CODEX_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
-CODEX_MAX_VALID_THINKING_MODES = CODEX_VALID_THINKING_MODES | {"max"}
-CODEX_MAX_MODEL_IDS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"})
-# Per Codex's model registry, `ultra` (max reasoning + automatic task
-# delegation) is supported by Sol/Terra but not Luna.
-CODEX_ULTRA_VALID_THINKING_MODES = CODEX_MAX_VALID_THINKING_MODES | {"ultra"}
-CODEX_ULTRA_MODEL_IDS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra"})
-COPILOT_MAX_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh", "max"})
-COPILOT_MAX_MODEL_IDS = frozenset(
-    {
-        "copilot:claude-sonnet-5",
-        "copilot:claude-fable-5",
-        "copilot:claude-opus-5",
-        "copilot:claude-opus-4.8",
-        "copilot:claude-opus-4.8-fast",
-        "copilot:claude-opus-4.7",
-        "copilot:gpt-5.6-sol",
-        "copilot:gpt-5.6-terra",
-        "copilot:gpt-5.6-luna",
-    }
-)
-COPILOT_NO_XHIGH_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "max"})
-COPILOT_NO_XHIGH_MODEL_IDS = frozenset(
-    {"copilot:claude-sonnet-4.6", "copilot:claude-opus-4.6"}
-)
-COPILOT_XHIGH_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
-COPILOT_XHIGH_MODEL_IDS = frozenset(
-    {
-        "copilot:gpt-5.5",
-        "copilot:gpt-5.4",
-        "copilot:gpt-5.4-mini",
-        "copilot:gpt-5.3-codex",
-    }
-)
-COPILOT_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
-COPILOT_REASONING_MODEL_IDS = frozenset(
-    {
-        "copilot:gpt-5-mini",
-        "copilot:mai-code-1-flash-picker",
-        "copilot:gemini-3.8-flash",
-        "copilot:gemini-3.6-flash",
-        "copilot:gemini-3.5-flash",
-        "copilot:gemini-3.1-pro-preview",
-        "copilot:grok-4.5",
-    }
-)
-COPILOT_KIMI_K3_VALID_THINKING_MODES = frozenset({"low", "high", "max"})
-
-# Cursor CLI exposes three ACP session modes (see https://cursor.com/docs/cli/acp).
-CURSOR_SESSION_MODES = frozenset({"agent", "plan", "ask"})
-
-ANTIGRAVITY_SESSION_MODES = frozenset({"default", "auto_edit", "yolo"})
-ANTIGRAVITY_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
-ANTIGRAVITY_PRO_VALID_THINKING_MODES = frozenset({"low", "high"})
-ANTIGRAVITY_PRO_MODEL_ID = "antigravity:gemini-3.1-pro"
-
-# Current stable Grok advertises no ACP session modes and silently ignores
-# set_mode ids. `always-approve` uses the launch flag; `auto` keeps the CLI's
-# default classifier behavior (routine calls pass, risky ones prompt); `plan`
-# stays for the set_mode plan-hop and revives if ACP modes return.
-GROK_SESSION_MODES = frozenset({"auto", "always-approve", "plan"})
-# Grok 4.5 exposes low/medium/high reasoning effort and Grok 4.6 adds xhigh;
-# the effort launch flag is skipped for models outside these allowlists.
-GROK_VALID_THINKING_MODES = frozenset({"low", "medium", "high"})
-GROK_REASONING_MODEL_IDS = frozenset({"grok:grok-4.5", "grok:grok-4.6"})
-GROK_XHIGH_VALID_THINKING_MODES = frozenset({"low", "medium", "high", "xhigh"})
-GROK_XHIGH_MODEL_IDS = frozenset({"grok:grok-4.6"})
-
-# OpenCode's built-in primary agents double as ACP session modes; `plan`
-# restricts edits to `.opencode/plans/*.md`, `build` has full tool access.
-OPENCODE_SESSION_MODES = frozenset({"build", "plan"})
-
 # Full-execution mode per agent for unattended one-shots (Codex rejects unknown modes; avoid plan/read-only).
 NORMAL_SESSION_MODE: dict[AgentKind, PermissionMode] = {
     AgentKind.ANTIGRAVITY: "yolo",
@@ -154,51 +59,6 @@ PERSONAS_SUPPORTED_AGENTS: frozenset[AgentKind] = frozenset(
 
 
 THINKING_MODE_ORDER = ("low", "medium", "high", "xhigh", "max", "ultra")
-
-
-def valid_thinking_modes(agent_kind: AgentKind, model_id: str) -> frozenset[str]:
-    # Accepted thinking tiers; empty = no effort dial (thinking_mode ignored).
-    if agent_kind is AgentKind.ANTIGRAVITY:
-        return (
-            ANTIGRAVITY_PRO_VALID_THINKING_MODES
-            if model_id == ANTIGRAVITY_PRO_MODEL_ID
-            else ANTIGRAVITY_VALID_THINKING_MODES
-        )
-    if agent_kind is AgentKind.CLAUDE:
-        if model_id in CLAUDE_NO_EFFORT_MODEL_IDS:
-            return frozenset()
-        return (
-            CLAUDE_XHIGH_VALID_THINKING_MODES
-            if model_id in CLAUDE_XHIGH_MODEL_IDS
-            else CLAUDE_VALID_THINKING_MODES
-        )
-    if agent_kind is AgentKind.CODEX:
-        if model_id in CODEX_ULTRA_MODEL_IDS:
-            return CODEX_ULTRA_VALID_THINKING_MODES
-        if model_id in CODEX_MAX_MODEL_IDS:
-            return CODEX_MAX_VALID_THINKING_MODES
-        return CODEX_VALID_THINKING_MODES
-    if agent_kind is AgentKind.COPILOT:
-        if model_id in COPILOT_MAX_MODEL_IDS:
-            return COPILOT_MAX_VALID_THINKING_MODES
-        if model_id in COPILOT_NO_XHIGH_MODEL_IDS:
-            return COPILOT_NO_XHIGH_VALID_THINKING_MODES
-        if model_id in COPILOT_XHIGH_MODEL_IDS:
-            return COPILOT_XHIGH_VALID_THINKING_MODES
-        if model_id in COPILOT_REASONING_MODEL_IDS:
-            return COPILOT_VALID_THINKING_MODES
-        if model_id == "copilot:kimi-k3":
-            return COPILOT_KIMI_K3_VALID_THINKING_MODES
-        return frozenset()
-    if agent_kind is AgentKind.GROK:
-        if model_id in GROK_XHIGH_MODEL_IDS:
-            return GROK_XHIGH_VALID_THINKING_MODES
-        return (
-            GROK_VALID_THINKING_MODES
-            if model_id in GROK_REASONING_MODEL_IDS
-            else frozenset()
-        )
-    return frozenset()
 
 
 def coerce_thinking_mode(
@@ -227,11 +87,6 @@ def build_system_prompt_meta(
 
 
 @dataclass(frozen=True)
-class PermissionConfig:
-    session_mode: str
-
-
-@dataclass(frozen=True)
 class LaunchConfig:
     # Spawn recipe: binary, CLI flags, launch-only env (e.g. CODEX_CONFIG).
     binary: str
@@ -245,18 +100,24 @@ class SessionConfig:
     meta: dict[str, Any] = field(default_factory=dict)
     env_overrides: dict[str, str] = field(default_factory=dict)
     reasoning_effort: str | None = None
-    permission: PermissionConfig = field(
-        default_factory=lambda: PermissionConfig(session_mode="default")
-    )
+    session_mode: str = "default"
 
 
-class AgentAdapter(ABC):
+class AgentAdapter:
     # Per-agent ACP differences (flags/env/meta/permissions) behind a uniform AcpSessionConfig.
+    binary: str
+    cli_args: tuple[str, ...] = ()
+    # Registry keys are namespaced ("copilot:gpt-5.5"); the CLI wants the bare id.
+    model_id_namespace = ""
+    # Persisted settings may carry a mode string from a previously selected
+    # agent; anything outside `session_modes` maps to `fallback_session_mode`.
+    session_modes: frozenset[str] = frozenset()
+    fallback_session_mode = "default"
+    default_thinking_mode = "medium"
+    # Session config option that takes the reasoning effort, for agents that
+    # expose one; None = effort is delivered another way (or not at all).
+    effort_config_id: str | None = None
 
-    def __init__(self, kind: AgentKind) -> None:
-        self.kind = kind
-
-    @abstractmethod
     def build_launch_config(
         self,
         *,
@@ -266,9 +127,8 @@ class AgentAdapter(ABC):
         reasoning_effort: str | None = None,
         permission_mode: str | None = None,
     ) -> LaunchConfig:
-        raise NotImplementedError
+        return LaunchConfig(binary=self.binary, cli_args=list(self.cli_args))
 
-    @abstractmethod
     def build_session_config(
         self,
         *,
@@ -278,21 +138,49 @@ class AgentAdapter(ABC):
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
-        raise NotImplementedError
+        return SessionConfig(
+            meta=self.build_session_meta(system_prompt, system_prompt_is_full_replace),
+            env_overrides=self.build_session_env(model_id),
+            reasoning_effort=self.reasoning_effort(model_id, thinking_mode),
+            session_mode=self.map_session_mode(permission_mode),
+        )
 
-    @abstractmethod
+    def build_session_meta(
+        self, system_prompt: str | None, system_prompt_is_full_replace: bool
+    ) -> dict[str, Any]:
+        return build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
+
+    def build_session_env(self, model_id: str) -> dict[str, str]:
+        return {}
+
+    def valid_thinking_modes(self, model_id: str) -> frozenset[str]:
+        # Accepted thinking tiers; empty = no effort dial (thinking_mode ignored).
+        return frozenset()
+
+    def reasoning_effort(self, model_id: str, thinking_mode: str | None) -> str | None:
+        modes = self.valid_thinking_modes(model_id)
+        if not modes:
+            return None
+        return coerce_thinking_mode(thinking_mode, modes, self.default_thinking_mode)
+
     def map_session_mode(self, permission_mode: str) -> str:
         # UI permission mode → ACP session mode id (plan-mode transitions).
-        raise NotImplementedError
+        if permission_mode in self.session_modes:
+            return permission_mode
+        return self.fallback_session_mode
 
     def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
-        # Registry key → agent model id (default passthrough).
-        return model_id
+        return model_id.removeprefix(self.model_id_namespace)
 
 
 class ClaudeAgentAdapter(AgentAdapter):
-    def __init__(self) -> None:
-        super().__init__(kind=AgentKind.CLAUDE)
+    binary = "claude-agent-acp"
+    effort_config_id = "effort"
+    XHIGH_MODEL_IDS = frozenset({"claude-fable-5-1", "claude-fable-5", "claude-opus-5"})
+    # claude-agent-acp only advertises the "effort" config option for models that
+    # report supportsEffort — Haiku doesn't, so set_config_option("effort") fails
+    # with "Unknown config option: effort".
+    NO_EFFORT_MODEL_IDS = frozenset({"haiku"})
 
     def build_launch_config(
         self,
@@ -304,48 +192,45 @@ class ClaudeAgentAdapter(AgentAdapter):
         permission_mode: str | None = None,
     ) -> LaunchConfig:
         return LaunchConfig(
-            binary="claude-agent-acp",
-            env={"CLAUDE_CODE_EXECUTABLE": "claude"},
+            binary=self.binary, env={"CLAUDE_CODE_EXECUTABLE": "claude"}
         )
 
-    def build_session_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        model_id: str,
-        thinking_mode: str | None,
-        permission_mode: str,
-    ) -> SessionConfig:
+    def build_session_meta(
+        self, system_prompt: str | None, system_prompt_is_full_replace: bool
+    ) -> dict[str, Any]:
         meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
         # Effort controls depth; visible thinking requires the SDK display option.
         meta["claudeCode"] = {
             "options": {"thinking": {"type": "adaptive", "display": "summarized"}}
         }
+        return meta
 
-        # Claude exposes thinking budget as the "effort" session config option,
-        # applied post-handshake via set_config_option; the UI's named tiers
-        # are passed through directly as effort level IDs. Models without the
-        # effort dial (Haiku) get None so that call is skipped entirely.
-        claude_modes = valid_thinking_modes(AgentKind.CLAUDE, model_id)
-        reasoning_effort = (
-            coerce_thinking_mode(thinking_mode, claude_modes) if claude_modes else None
-        )
+    def build_session_env(self, model_id: str) -> dict[str, str]:
+        return {"ANTHROPIC_MODEL": model_id}
 
-        return SessionConfig(
-            meta=meta,
-            env_overrides={"ANTHROPIC_MODEL": model_id},
-            reasoning_effort=reasoning_effort,
-            permission=PermissionConfig(session_mode=permission_mode),
-        )
+    def valid_thinking_modes(self, model_id: str) -> frozenset[str]:
+        if model_id in self.NO_EFFORT_MODEL_IDS:
+            return frozenset()
+        if model_id in self.XHIGH_MODEL_IDS:
+            return frozenset({"low", "medium", "high", "xhigh", "max"})
+        return frozenset({"low", "medium", "high", "max"})
 
     def map_session_mode(self, permission_mode: str) -> str:
         return permission_mode
 
 
 class CodexAgentAdapter(AgentAdapter):
-    def __init__(self) -> None:
-        super().__init__(kind=AgentKind.CODEX)
+    binary = "codex-acp"
+    # UI permission mode → codex-acp session mode (each bundles approval + sandbox policy).
+    SESSION_MODE_IDS = {
+        "auto": "agent",
+        "read-only": "read-only",
+        "full-access": "agent-full-access",
+    }
+    MAX_MODEL_IDS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"})
+    # Per Codex's model registry, `ultra` (max reasoning + automatic task
+    # delegation) is supported by Sol/Terra but not Luna.
+    ULTRA_MODEL_IDS = frozenset({"gpt-5.6-sol", "gpt-5.6-terra"})
 
     def build_launch_config(
         self,
@@ -370,145 +255,125 @@ class CodexAgentAdapter(AgentAdapter):
             else:
                 config["developer_instructions"] = system_prompt
         env = {"CODEX_CONFIG": json.dumps(config)} if config else {}
-        return LaunchConfig(binary="codex-acp", env=env)
+        return LaunchConfig(binary=self.binary, env=env)
 
-    def build_session_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        model_id: str,
-        thinking_mode: str | None,
-        permission_mode: str,
-    ) -> SessionConfig:
-        reasoning_effort = coerce_thinking_mode(
-            thinking_mode, valid_thinking_modes(AgentKind.CODEX, model_id)
-        )
+    def build_session_meta(
+        self, system_prompt: str | None, system_prompt_is_full_replace: bool
+    ) -> dict[str, Any]:
+        return {}
 
-        # Config via CODEX_CONFIG + model ID, not session meta.
-        return SessionConfig(
-            reasoning_effort=reasoning_effort,
-            permission=PermissionConfig(
-                session_mode=self.map_session_mode(permission_mode)
-            ),
-        )
+    def valid_thinking_modes(self, model_id: str) -> frozenset[str]:
+        if model_id in self.ULTRA_MODEL_IDS:
+            return frozenset({"low", "medium", "high", "xhigh", "max", "ultra"})
+        if model_id in self.MAX_MODEL_IDS:
+            return frozenset({"low", "medium", "high", "xhigh", "max"})
+        return frozenset({"low", "medium", "high", "xhigh"})
 
     def map_session_mode(self, permission_mode: str) -> str:
         # Invalid modes indicate a caller bug; fail here so the session
         # doesn't silently start with broader or different permissions.
-        if permission_mode not in CODEX_SESSION_MODES:
+        if permission_mode not in self.SESSION_MODE_IDS:
             raise ValueError("Invalid Codex session mode: " + permission_mode)
-        return CODEX_SESSION_MODES[permission_mode]
+        return self.SESSION_MODE_IDS[permission_mode]
+
+    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
+        # codex-acp encodes reasoning effort inside the model ID and rejects
+        # bare IDs ("modelId[effort]" is the required format).
+        if reasoning_effort:
+            return f"{model_id}[{reasoning_effort}]"
+        return model_id
 
 
 class CopilotCliAdapter(AgentAdapter):
     # Copilot modes/reasoning differ from Claude — only send advertised values.
+    binary = "copilot"
+    cli_args = ("--acp", "--stdio")
+    model_id_namespace = "copilot:"
+    session_modes = frozenset({"agent", "plan", "autopilot"})
+    fallback_session_mode = "agent"
+    default_thinking_mode = "high"
+    effort_config_id = "reasoning_effort"
+    SESSION_MODE_BASE_URL = "https://agentclientprotocol.com/protocol/session-modes"
+    MAX_MODEL_IDS = frozenset(
+        {
+            "copilot:claude-sonnet-5",
+            "copilot:claude-fable-5",
+            "copilot:claude-opus-5",
+            "copilot:claude-opus-4.8",
+            "copilot:claude-opus-4.8-fast",
+            "copilot:claude-opus-4.7",
+            "copilot:gpt-5.6-sol",
+            "copilot:gpt-5.6-terra",
+            "copilot:gpt-5.6-luna",
+        }
+    )
+    NO_XHIGH_MODEL_IDS = frozenset(
+        {"copilot:claude-sonnet-4.6", "copilot:claude-opus-4.6"}
+    )
+    XHIGH_MODEL_IDS = frozenset(
+        {
+            "copilot:gpt-5.5",
+            "copilot:gpt-5.4",
+            "copilot:gpt-5.4-mini",
+            "copilot:gpt-5.3-codex",
+        }
+    )
+    REASONING_MODEL_IDS = frozenset(
+        {
+            "copilot:gpt-5-mini",
+            "copilot:mai-code-1-flash-picker",
+            "copilot:gemini-3.8-flash",
+            "copilot:gemini-3.6-flash",
+            "copilot:gemini-3.5-flash",
+            "copilot:gemini-3.1-pro-preview",
+            "copilot:grok-4.5",
+        }
+    )
 
-    def __init__(self) -> None:
-        super().__init__(kind=AgentKind.COPILOT)
-
-    def build_launch_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        instructions_file_path: str | None = None,
-        reasoning_effort: str | None = None,
-        permission_mode: str | None = None,
-    ) -> LaunchConfig:
-        return LaunchConfig(binary="copilot", cli_args=["--acp", "--stdio"])
-
-    def build_session_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        model_id: str,
-        thinking_mode: str | None,
-        permission_mode: str,
-    ) -> SessionConfig:
-        meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
-
-        copilot_modes = valid_thinking_modes(AgentKind.COPILOT, model_id)
-        reasoning_effort = (
-            coerce_thinking_mode(thinking_mode, copilot_modes, default="high")
-            if copilot_modes
-            else None
-        )
-
-        return SessionConfig(
-            meta=meta,
-            reasoning_effort=reasoning_effort,
-            permission=PermissionConfig(
-                session_mode=self.map_session_mode(permission_mode)
-            ),
-        )
+    def valid_thinking_modes(self, model_id: str) -> frozenset[str]:
+        if model_id in self.MAX_MODEL_IDS:
+            return frozenset({"low", "medium", "high", "xhigh", "max"})
+        if model_id in self.NO_XHIGH_MODEL_IDS:
+            return frozenset({"low", "medium", "high", "max"})
+        if model_id in self.XHIGH_MODEL_IDS:
+            return frozenset({"low", "medium", "high", "xhigh"})
+        if model_id in self.REASONING_MODEL_IDS:
+            return frozenset({"low", "medium", "high"})
+        if model_id == "copilot:kimi-k3":
+            return frozenset({"low", "high", "max"})
+        return frozenset()
 
     def map_session_mode(self, permission_mode: str) -> str:
-        # Existing chats may still carry Claude/Codex mode strings in persisted
-        # settings. Default those to Copilot's normal agent mode so agent
-        # switches do not fail.
-        if permission_mode not in COPILOT_SESSION_MODES:
-            return COPILOT_SESSION_MODE_IDS["agent"]
-        return COPILOT_SESSION_MODE_IDS[permission_mode]
-
-    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
-        # Strip "copilot:" namespace for the CLI.
-        return model_id.removeprefix("copilot:")
+        return (
+            f"{self.SESSION_MODE_BASE_URL}#{super().map_session_mode(permission_mode)}"
+        )
 
 
 class CursorAgentAdapter(AgentAdapter):
     # Cursor bakes effort into the model ID (`-low`/`-high`/…); no separate thinking flag.
-
-    def __init__(self) -> None:
-        super().__init__(kind=AgentKind.CURSOR)
-
-    def build_launch_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        instructions_file_path: str | None = None,
-        reasoning_effort: str | None = None,
-        permission_mode: str | None = None,
-    ) -> LaunchConfig:
-        return LaunchConfig(binary="cursor-agent", cli_args=["acp"])
-
-    def build_session_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        model_id: str,
-        thinking_mode: str | None,
-        permission_mode: str,
-    ) -> SessionConfig:
-        meta = build_system_prompt_meta(system_prompt, system_prompt_is_full_replace)
-        return SessionConfig(
-            meta=meta,
-            permission=PermissionConfig(
-                session_mode=self.map_session_mode(permission_mode)
-            ),
-        )
-
-    def map_session_mode(self, permission_mode: str) -> str:
-        # Persisted settings may still carry Claude/Codex/Copilot mode strings
-        # from a previous agent. Default to Cursor's normal agent mode so
-        # agent switches don't fail.
-        if permission_mode not in CURSOR_SESSION_MODES:
-            return "agent"
-        return permission_mode
-
-    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
-        # Strip "cursor:" namespace for the CLI.
-        return model_id.removeprefix("cursor:")
+    binary = "cursor-agent"
+    cli_args = ("acp",)
+    model_id_namespace = "cursor:"
+    # Cursor CLI exposes three ACP session modes (see https://cursor.com/docs/cli/acp).
+    session_modes = frozenset({"agent", "plan", "ask"})
+    fallback_session_mode = "agent"
 
 
 class GrokAgentAdapter(AgentAdapter):
     # Effort and permission mode are launch-baked; changes respawn via fingerprint.
-
-    def __init__(self) -> None:
-        super().__init__(kind=AgentKind.GROK)
+    binary = "grok"
+    model_id_namespace = "grok:"
+    # Current stable Grok advertises no ACP session modes and silently ignores
+    # set_mode ids. `always-approve` uses the launch flag; `auto` keeps the CLI's
+    # default classifier behavior (routine calls pass, risky ones prompt); `plan`
+    # stays for the set_mode plan-hop and revives if ACP modes return. The legacy
+    # `code` mode never prompted, so it falls back to always-approve.
+    session_modes = frozenset({"auto", "always-approve", "plan"})
+    fallback_session_mode = "always-approve"
+    # Grok 4.5 exposes low/medium/high reasoning effort and Grok 4.6 adds xhigh;
+    # the effort launch flag is skipped for models outside these allowlists.
+    REASONING_MODEL_IDS = frozenset({"grok:grok-4.5", "grok:grok-4.6"})
+    XHIGH_MODEL_IDS = frozenset({"grok:grok-4.6"})
 
     def build_launch_config(
         self,
@@ -529,132 +394,78 @@ class GrokAgentAdapter(AgentAdapter):
         if reasoning_effort:
             cli_args.extend(["--reasoning-effort", reasoning_effort])
         cli_args.append("stdio")
-        return LaunchConfig(binary="grok", cli_args=cli_args)
+        return LaunchConfig(binary=self.binary, cli_args=cli_args)
 
-    def build_session_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        model_id: str,
-        thinking_mode: str | None,
-        permission_mode: str,
-    ) -> SessionConfig:
+    def build_session_meta(
+        self, system_prompt: str | None, system_prompt_is_full_replace: bool
+    ) -> dict[str, Any]:
         # Grok's session/new _meta supports systemPromptOverride (full
         # replacement) and rules (appended to the default prompt).
-        meta: dict[str, Any] = {}
-        if system_prompt:
-            if system_prompt_is_full_replace:
-                meta["systemPromptOverride"] = system_prompt
-            else:
-                meta["rules"] = system_prompt
+        if not system_prompt:
+            return {}
+        if system_prompt_is_full_replace:
+            return {"systemPromptOverride": system_prompt}
+        return {"rules": system_prompt}
 
-        grok_modes = valid_thinking_modes(AgentKind.GROK, model_id)
-        reasoning_effort = (
-            coerce_thinking_mode(thinking_mode, grok_modes) if grok_modes else None
-        )
-
-        return SessionConfig(
-            meta=meta,
-            reasoning_effort=reasoning_effort,
-            permission=PermissionConfig(
-                session_mode=self.map_session_mode(permission_mode)
-            ),
-        )
-
-    def map_session_mode(self, permission_mode: str) -> str:
-        # Persisted settings may carry mode strings from a different agent or
-        # the legacy Grok `code` mode. Map those to always-approve — it matches
-        # code mode's old behavior of never prompting.
-        if permission_mode not in GROK_SESSION_MODES:
-            return "always-approve"
-        return permission_mode
-
-    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
-        # Strip "grok:" namespace for the CLI.
-        return model_id.removeprefix("grok:")
+    def valid_thinking_modes(self, model_id: str) -> frozenset[str]:
+        if model_id in self.XHIGH_MODEL_IDS:
+            return frozenset({"low", "medium", "high", "xhigh"})
+        if model_id in self.REASONING_MODEL_IDS:
+            return frozenset({"low", "medium", "high"})
+        return frozenset()
 
 
 class AntigravityAgentAdapter(AgentAdapter):
-    def __init__(self) -> None:
-        super().__init__(kind=AgentKind.ANTIGRAVITY)
+    binary = "agy-acp-server"
+    model_id_namespace = "antigravity:"
+    session_modes = frozenset({"default", "auto_edit", "yolo"})
+    fallback_session_mode = "yolo"
+    default_thinking_mode = "high"
+    PRO_MODEL_ID = "antigravity:gemini-3.1-pro"
+    # OAuth-path server IDs; API-key auth advertises different unsupported IDs.
+    OAUTH_MODEL_IDS = {
+        ("gemini-3.5-flash", "high"): "gemini-3-flash-agent",
+        ("gemini-3.5-flash", "medium"): "gemini-3.5-flash-low",
+        ("gemini-3.5-flash", "low"): "gemini-3.5-flash-extra-low",
+        ("gemini-3.1-pro", "high"): "gemini-pro-agent",
+        ("gemini-3.1-pro", "low"): "gemini-3.1-pro-low",
+    }
 
-    def build_launch_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        instructions_file_path: str | None = None,
-        reasoning_effort: str | None = None,
-        permission_mode: str | None = None,
-    ) -> LaunchConfig:
-        return LaunchConfig(binary="agy-acp-server")
+    def valid_thinking_modes(self, model_id: str) -> frozenset[str]:
+        if model_id == self.PRO_MODEL_ID:
+            return frozenset({"low", "high"})
+        return frozenset({"low", "medium", "high"})
 
-    def build_session_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        model_id: str,
-        thinking_mode: str | None,
-        permission_mode: str,
-    ) -> SessionConfig:
-        reasoning_effort = (
-            "high"
-            if model_id == ANTIGRAVITY_PRO_MODEL_ID and thinking_mode == "medium"
-            else coerce_thinking_mode(
-                thinking_mode,
-                valid_thinking_modes(AgentKind.ANTIGRAVITY, model_id),
-                default="high",
-            )
+    def reasoning_effort(self, model_id: str, thinking_mode: str | None) -> str:
+        # Pro has no medium tier; round it up rather than down to low.
+        if model_id == self.PRO_MODEL_ID and thinking_mode == "medium":
+            return "high"
+        return coerce_thinking_mode(
+            thinking_mode,
+            self.valid_thinking_modes(model_id),
+            self.default_thinking_mode,
         )
-        return SessionConfig(
-            meta=build_system_prompt_meta(system_prompt, system_prompt_is_full_replace),
-            reasoning_effort=reasoning_effort,
-            permission=PermissionConfig(
-                session_mode=self.map_session_mode(permission_mode)
-            ),
-        )
-
-    def map_session_mode(self, permission_mode: str) -> str:
-        if permission_mode not in ANTIGRAVITY_SESSION_MODES:
-            return "yolo"
-        return permission_mode
 
     def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
-        effort = reasoning_effort or "high"
-        if model_id == ANTIGRAVITY_PRO_MODEL_ID and effort == "medium":
-            effort = "high"
-        server_model_id = model_id.removeprefix("antigravity:")
-        # OAuth-path server IDs; API-key auth advertises different unsupported IDs.
-        oauth_model_ids = {
-            ("gemini-3.5-flash", "high"): "gemini-3-flash-agent",
-            ("gemini-3.5-flash", "medium"): "gemini-3.5-flash-low",
-            ("gemini-3.5-flash", "low"): "gemini-3.5-flash-extra-low",
-            ("gemini-3.1-pro", "high"): "gemini-pro-agent",
-            ("gemini-3.1-pro", "low"): "gemini-3.1-pro-low",
-        }
-        return oauth_model_ids.get(
+        effort = self.reasoning_effort(model_id, reasoning_effort)
+        server_model_id = model_id.removeprefix(self.model_id_namespace)
+        return self.OAUTH_MODEL_IDS.get(
             (server_model_id, effort), f"{server_model_id}-{effort}"
         )
 
 
 class OpencodeAgentAdapter(AgentAdapter):
     # Primary agents map to session modes; no uniform ACP reasoning dial (thinking UI hidden).
-
-    def __init__(self) -> None:
-        super().__init__(kind=AgentKind.OPENCODE)
-
-    def build_launch_config(
-        self,
-        *,
-        system_prompt: str | None,
-        system_prompt_is_full_replace: bool,
-        instructions_file_path: str | None = None,
-        reasoning_effort: str | None = None,
-        permission_mode: str | None = None,
-    ) -> LaunchConfig:
-        return LaunchConfig(binary="opencode", cli_args=["acp"])
+    binary = "opencode"
+    cli_args = ("acp",)
+    model_id_namespace = "opencode:"
+    # OpenCode's built-in primary agents double as ACP session modes; `plan`
+    # restricts edits to `.opencode/plans/*.md`, `build` has full tool access.
+    # Unknown modes fall back to plan so switching agents never silently widens
+    # permissions — e.g. a chat left in Codex's read-only mode shouldn't become
+    # opencode full-access just because the string doesn't map.
+    session_modes = frozenset({"build", "plan"})
+    fallback_session_mode = "plan"
 
     def build_session_config(
         self,
@@ -665,61 +476,53 @@ class OpencodeAgentAdapter(AgentAdapter):
         thinking_mode: str | None,
         permission_mode: str,
     ) -> SessionConfig:
-        if system_prompt and system_prompt_is_full_replace:
-            # OpenCode ignores ACP _meta.systemPrompt, so inject the persona as
-            # a custom primary agent via OPENCODE_CONFIG_CONTENT and select it
-            # as the session mode.
-            mode = self.map_session_mode(permission_mode)
-            agent_name = f"agentrove-persona-{mode}"
-            permission: dict[str, Any] = (
-                {"question": "allow", "plan_enter": "allow"}
-                if mode == "build"
-                else {
-                    "question": "allow",
-                    "plan_exit": "allow",
-                    "edit": {
-                        "*": "deny",
-                        ".opencode/plans/*.md": "allow",
-                    },
-                }
+        if not (system_prompt and system_prompt_is_full_replace):
+            return super().build_session_config(
+                system_prompt=system_prompt,
+                system_prompt_is_full_replace=system_prompt_is_full_replace,
+                model_id=model_id,
+                thinking_mode=thinking_mode,
+                permission_mode=permission_mode,
             )
-            config_content = json.dumps(
-                {
-                    "agent": {
-                        agent_name: {
-                            "description": "Agentrove persona",
-                            "mode": "primary",
-                            "prompt": system_prompt,
-                            "permission": permission,
-                        }
-                    },
-                    "default_agent": agent_name,
-                }
-            )
-            return SessionConfig(
-                env_overrides={"OPENCODE_CONFIG_CONTENT": config_content},
-                permission=PermissionConfig(session_mode=agent_name),
-            )
-
+        # OpenCode ignores ACP _meta.systemPrompt, so inject the persona as
+        # a custom primary agent via OPENCODE_CONFIG_CONTENT and select it
+        # as the session mode.
+        mode = self.map_session_mode(permission_mode)
+        agent_name = f"agentrove-persona-{mode}"
+        permission: dict[str, Any] = (
+            {"question": "allow", "plan_enter": "allow"}
+            if mode == "build"
+            else {
+                "question": "allow",
+                "plan_exit": "allow",
+                "edit": {
+                    "*": "deny",
+                    ".opencode/plans/*.md": "allow",
+                },
+            }
+        )
+        config_content = json.dumps(
+            {
+                "agent": {
+                    agent_name: {
+                        "description": "Agentrove persona",
+                        "mode": "primary",
+                        "prompt": system_prompt,
+                        "permission": permission,
+                    }
+                },
+                "default_agent": agent_name,
+            }
+        )
         return SessionConfig(
-            permission=PermissionConfig(
-                session_mode=self.map_session_mode(permission_mode)
-            ),
+            env_overrides={"OPENCODE_CONFIG_CONTENT": config_content},
+            session_mode=agent_name,
         )
 
-    def map_session_mode(self, permission_mode: str) -> str:
-        # Persisted settings may still carry mode strings from a different
-        # previous agent. Default to the restrictive mode (plan) so switching
-        # agents never silently widens permissions — e.g. a chat left in
-        # Codex's read-only mode shouldn't become opencode full-access just
-        # because the string doesn't map.
-        if permission_mode not in OPENCODE_SESSION_MODES:
-            return "plan"
-        return permission_mode
-
-    def map_model_id(self, model_id: str, reasoning_effort: str | None = None) -> str:
-        # Strip "opencode:" namespace for the CLI.
-        return model_id.removeprefix("opencode:")
+    def build_session_meta(
+        self, system_prompt: str | None, system_prompt_is_full_replace: bool
+    ) -> dict[str, Any]:
+        return {}
 
 
 AGENT_ADAPTERS: dict[AgentKind, AgentAdapter] = {

--- a/backend/app/services/acp/session.py
+++ b/backend/app/services/acp/session.py
@@ -65,11 +65,7 @@ NON_IMAGE_MIME: dict[str, str] = {
 
 EMPTY_FROZENSET: frozenset[str] = frozenset()
 
-# Claude's thinking budget is advertised as the "effort" session config
-# option; value IDs are the supported Claude UI tiers.
-CLAUDE_EFFORT_CONFIG_ID = "effort"
-CLAUDE_MODEL_CONFIG_ID = "model"
-COPILOT_EFFORT_CONFIG_ID = "reasoning_effort"
+MODEL_CONFIG_ID = "model"
 
 # codex-acp advertises Fast mode as a session config option (select on/off, or
 # boolean when the client supports it). Values match FastModeConfig.ts.
@@ -265,20 +261,16 @@ class AcpSession:
             )
         except Exception:
             logger.warning("Failed to set ACP model: %s", model_id, exc_info=True)
-        else:
-            if self._agent_kind == AgentKind.COPILOT and reasoning_effort:
-                try:
-                    await self._conn.set_config_option(
-                        config_id=COPILOT_EFFORT_CONFIG_ID,
-                        session_id=self.acp_session_id,
-                        value=reasoning_effort,
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to set Copilot effort: %s",
-                        reasoning_effort,
-                        exc_info=True,
-                    )
+            return
+        # Effort options are model-scoped for some agents, so re-apply after a switch.
+        try:
+            await self._set_effort_on_conn(
+                self._conn, self._agent_kind, self.acp_session_id, reasoning_effort
+            )
+        except Exception:
+            logger.warning(
+                "Failed to set ACP effort: %s", reasoning_effort, exc_info=True
+            )
 
     async def set_mode(self, mode_id: str) -> None:
         try:
@@ -431,7 +423,6 @@ class AcpSession:
                 )
                 acp_session_id = response.session_id
 
-            model_set = False
             if config.model:
                 try:
                     await cls._set_model_on_conn(
@@ -441,7 +432,6 @@ class AcpSession:
                         config.model,
                         config.reasoning_effort,
                     )
-                    model_set = True
                 except Exception:
                     logger.warning(
                         "Failed to set initial model: %s", config.model, exc_info=True
@@ -462,41 +452,16 @@ class AcpSession:
                         exc_info=True,
                     )
 
-            # Claude receives thinking budget via the "effort" session config
-            # option (not launch CLI args), so it must be applied after
-            # new_session/load_session. Codex carries effort inside the
-            # model[effort] ID set above, so it doesn't need this step.
-            if config.agent_kind == AgentKind.CLAUDE and config.reasoning_effort:
-                try:
-                    await conn.set_config_option(
-                        config_id=CLAUDE_EFFORT_CONFIG_ID,
-                        session_id=acp_session_id,
-                        value=config.reasoning_effort,
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to set initial effort: %s",
-                        config.reasoning_effort,
-                        exc_info=True,
-                    )
-
-            if (
-                config.agent_kind == AgentKind.COPILOT
-                and config.reasoning_effort
-                and model_set
-            ):
-                try:
-                    await conn.set_config_option(
-                        config_id=COPILOT_EFFORT_CONFIG_ID,
-                        session_id=acp_session_id,
-                        value=config.reasoning_effort,
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to set initial Copilot effort: %s",
-                        config.reasoning_effort,
-                        exc_info=True,
-                    )
+            try:
+                await cls._set_effort_on_conn(
+                    conn, config.agent_kind, acp_session_id, config.reasoning_effort
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to set initial effort: %s",
+                    config.reasoning_effort,
+                    exc_info=True,
+                )
 
             # Fast mode is per-turn service tier state inside codex-acp; default
             # is off so only enable when the user opted in.
@@ -571,17 +536,27 @@ class AcpSession:
         model_id: str,
         reasoning_effort: str | None = None,
     ) -> None:
-        acp_model_id = AGENT_ADAPTERS[agent_kind].map_model_id(
-            model_id, reasoning_effort
-        )
-        # codex-acp encodes reasoning effort inside the model ID and rejects
-        # bare IDs ("modelId[effort]" is the required format).
-        if agent_kind == AgentKind.CODEX and reasoning_effort:
-            acp_model_id = f"{acp_model_id}[{reasoning_effort}]"
         await conn.set_config_option(
-            config_id=CLAUDE_MODEL_CONFIG_ID,
+            config_id=MODEL_CONFIG_ID,
             session_id=session_id,
-            value=acp_model_id,
+            value=AGENT_ADAPTERS[agent_kind].map_model_id(model_id, reasoning_effort),
+        )
+
+    @staticmethod
+    async def _set_effort_on_conn(
+        conn: ClientSideConnection,
+        agent_kind: AgentKind,
+        session_id: str,
+        reasoning_effort: str | None,
+    ) -> None:
+        # Only for agents whose effort is a session config option; it must be
+        # applied after new_session/load_session. Others carry effort in the
+        # model ID (Codex, Antigravity) or launch flags (Grok).
+        config_id = AGENT_ADAPTERS[agent_kind].effort_config_id
+        if config_id is None or not reasoning_effort:
+            return
+        await conn.set_config_option(
+            config_id=config_id, session_id=session_id, value=reasoning_effort
         )
 
     @staticmethod

--- a/backend/app/services/agent.py
+++ b/backend/app/services/agent.py
@@ -576,7 +576,7 @@ class AgentService:
                 chat_id, user_id, sandbox_provider
             ),
             model=model_id,
-            permission_mode=session_config.permission.session_mode,
+            permission_mode=session_config.session_mode,
             resume_session_id=session_id,
             workspace_path=workspace_path,
             system_prompt=system_prompt,


### PR DESCRIPTION
## Summary

Refactor of `backend/app/services/acp/adapters.py` (733 → ~480 lines) and the agent-specific branching that had leaked into `session.py`.

- `AgentAdapter.build_session_config` is now a template: it assembles meta / env / effort / session mode from per-adapter hooks, with data-driven defaults for `build_launch_config`, `map_session_mode` and `map_model_id` (`binary`, `cli_args`, `session_modes`, `fallback_session_mode`, `model_id_namespace`, `default_thinking_mode`). Cursor is now pure class attributes; most adapters override one or two hooks.
- `valid_thinking_modes` moves from a module-level `if agent_kind is …` dispatcher into each adapter; the ~25 `*_VALID_THINKING_MODES` / `*_MODEL_IDS` constants move with it. `ai_model.py` calls `AGENT_ADAPTERS[kind].valid_thinking_modes(mid)`.
- `PermissionConfig` (one-field wrapper) flattened into `SessionConfig.session_mode`; unused `AgentAdapter.kind` and the seven `__init__`s dropped.
- Antigravity's "pro + medium → high" rule lives once in `reasoning_effort`, reused by `map_model_id`.
- Codex's `model[effort]` suffix moves from `session.py` into `CodexAgentAdapter.map_model_id`, which already received the effort. `CLAUDE_MODEL_CONFIG_ID` → `MODEL_CONFIG_ID` (it was used for every agent).
- Effort delivery: new `AgentAdapter.effort_config_id` (`"effort"` for Claude, `"reasoning_effort"` for Copilot) and a single `AcpSession._set_effort_on_conn`, replacing three `if agent_kind == CLAUDE/COPILOT` blocks and the `model_set` flag.

## Behavior

Adapter outputs were brute-force compared against the previous implementation over 1.6M input combinations (every `MODELS` entry × thinking modes × permission modes × prompt variants for `build_launch_config`, `build_session_config`, `map_session_mode`, `map_model_id`, `valid_thinking_modes`): zero differences.

Intentional deltas, all on non-happy paths:
- `AntigravityAgentAdapter.map_model_id` coerces an out-of-range effort to a valid tier instead of emitting e.g. `gemini-…-xhigh` (unreachable in practice — callers pass the already-coerced effort).
- Copilot's initial effort is no longer skipped when the initial `set_model` failed (produces a second warning instead).
- Claude's effort is re-applied after a successful mid-session model switch (same value, no-op for the agent).

## Verification

- `pytest tests/test_acp.py tests/test_models.py` — 85 passed
- `ruff check` / `ruff format --check` clean
- `mypy app/` — unchanged (70 pre-existing errors, none in touched lines)